### PR TITLE
[Update]: added call_guard for unblocking GIL

### DIFF
--- a/python/bindings.cpp
+++ b/python/bindings.cpp
@@ -24,6 +24,7 @@ PYBIND11_MODULE(pylasr, m) {
 
     // Basic processing functions
     m.def("process", &process,
+          py::call_guard<py::gil_scoped_release>(),
           "Process a pipeline configuration file",
           py::arg("config_file"));
           


### PR DESCRIPTION
Avoid GIL update for free threads in python.