### PR TITLE
Python api fixes

### DIFF
--- a/python/bindings.cpp
+++ b/python/bindings.cpp
@@ -393,13 +393,19 @@ PYBIND11_MODULE(pylasr, m) {
     py::arg("connect_uid"), py::arg("operation") = "-", py::arg("store_in_attribute") = "", py::arg("bilinear") = true);
 
     // CRS operations
-    m.def("set_crs_epsg", &api::set_crs_epsg,
-          "Set CRS using EPSG code",
-          py::arg("epsg"));
-
-    m.def("set_crs_wkt", &api::set_crs_wkt,
-          "Set CRS using WKT string",
-          py::arg("wkt"));
+      m.def("set_crs", [](py::object crs) -> api::Pipeline {
+      api::Stage s("set_crs");
+      if (py::isinstance<py::int_>(crs)) {
+            s.set("epsg", crs.cast<int>());
+            s.set("wkt", "");
+      } else if (py::isinstance<py::str>(crs)) {
+            s.set("epsg", 0);
+            s.set("wkt", crs.cast<std::string>());
+      } else {
+            throw std::invalid_argument("crs must be either EPSG code (int) or WKT string");
+      }
+      return api::Pipeline(s);
+      }, "Set CRS using EPSG code or WKT string", py::arg("crs"));
 
     // Stop conditions
     m.def("stop_if_outside", &api::stop_if_outside,

--- a/python/bindings.cpp
+++ b/python/bindings.cpp
@@ -408,7 +408,7 @@ PYBIND11_MODULE(pylasr, m) {
 
     // Helper function for common DTM pipeline
     m.def("dtm_pipeline", [](double resolution, const std::string& ofile) -> api::Pipeline {
-        return api::classify_with_csf() + api::rasterize(resolution, resolution, {"min"}, {"Classification == 2 || Classification == 9"}, ofile);
+        return api::classify_with_csf() + api::rasterize(resolution, resolution, {"min"}, {"Classification %in% 2 9"}, ofile);
     }, "Create a DTM pipeline", py::arg("resolution"), py::arg("ofile"));
 
     // Helper function for common CHM pipeline  

--- a/python/bindings.cpp
+++ b/python/bindings.cpp
@@ -463,7 +463,7 @@ PYBIND11_MODULE(pylasr, m) {
 
     // Helper function for common DTM pipeline
     m.def("dtm_pipeline", [](double resolution, const std::string& ofile) -> api::Pipeline {
-        return api::classify_with_csf() + api::rasterize(resolution, resolution, {"min"}, {"Classification == 2"}, ofile);
+        return api::classify_with_csf() + api::rasterize(resolution, resolution, {"min"}, {"Classification == 2 || Classification == 9"}, ofile);
     }, "Create a DTM pipeline", py::arg("resolution"), py::arg("ofile"));
 
     // Helper function for common CHM pipeline  


### PR DESCRIPTION
# 📜PR Description

## Helper utilities for stage UIDs

- Added `get_stage_info` and `extract_uid` functions to retrieve the string `UID` from a `Pipeline` object or accept it directly from a string.

- All methods that take a `connect_uid` now handle both a `Pipeline` and a `UID` string by calling `extract_uid`.

## Overloaded and extended `info` function

- Replaced the simple `m.def("info", &api::info)` with two overloads:

    - **No arguments**: returns a `Pipeline` object configured with the info stage for later use.

    - **With a string argument**: immediately runs the pipeline on the specified file and prints the information.

## Unified CRS setting interface

- Removed separate `set_crs_epsg` and `set_crs_wkt` bindings.

- Introduced a single `m.def("set_crs", …)` that accepts either an `int` (EPSG code) or a `string` (WKT) to build the appropriate pipeline stage.

## Updated raster/matrix operation bindings

- Methods such as `rasterize_triangulation`, `focal`, `pit_fill`, `local_maximum_raster`, `hull_triangulation`, `region_growing`, `neighborhood_metrics`, and `transform_with` now accept a `py::object connect_uid` and use `extract_uid` to obtain the `UID`.

- For `transform_with`, added a type check to ensure the preceding stage is a _triangulation_, _raster_, or _matrix_ stage; otherwise an `invalid_argument` is thrown.

## Refactored Stage bindings

- Removed the explicit `py::class_<api::Stage>` and its `create_stage` method.

- Retained only the `create_pipeline()` function for creating an empty pipeline.

## Adjusted predefined pipelines

- In `dtm_pipeline`, expanded the classification filter from `"Classification == 2"` to `"Classification == 2 || Classification == 9"` to include an additional water category points.