### PR TITLE
Mac tests

### DIFF
--- a/.github/workflows/pylasr.yaml
+++ b/.github/workflows/pylasr.yaml
@@ -59,8 +59,8 @@ jobs:
 
     - name: Configure pybind11 path on Ubuntu/macOS
       run: |
-        PYBIND11_DIR=$(python -c "import pybind11; print(pybind11.get_cmake_dir())")
-        echo "pybind11_DIR=$PYBIND11_DIR" >> $GITHUB_ENV
+        pybind11_DIR=$(python -c "import pybind11; print(pybind11.get_cmake_dir())")
+        echo "pybind11_DIR=$pybind11_DIR" >> $GITHUB_ENV
 
     - name: Build extension on Ubuntu/macOS
       run: |

--- a/.github/workflows/pylasr.yaml
+++ b/.github/workflows/pylasr.yaml
@@ -13,6 +13,7 @@ on:
       - '.github/workflows/pylasr.yaml'
   workflow_dispatch:
 
+
 jobs:
   test:
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/pylasr.yaml
+++ b/.github/workflows/pylasr.yaml
@@ -13,14 +13,13 @@ on:
       - '.github/workflows/pylasr.yaml'
   workflow_dispatch:
 
-
 jobs:
   test:
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
       matrix:
-        os: ['ubuntu-latest']
+        os: ['ubuntu-latest', 'macos-latest']
         python-version: ['3.11', '3.12', '3.13']
         
     steps:
@@ -47,42 +46,29 @@ jobs:
           cmake \
           build-essential
 
-    - name: Install system dependencies (macOS)
+    - name: Install system dependencies on macOS
       if: runner.os == 'macOS'
       run: |
-        brew install \
-          gdal \
-          geos \
-          proj \
-          sqlite \
-          tbb \
-          cmake
+        brew update
+        brew install libomp gdal geos proj sqlite3 tbb cmake
 
-    - name: Install system dependencies (Windows)
-      if: runner.os == 'Windows'
-      run: |
-        choco install cmake --installargs 'ADD_CMAKE_TO_PATH=System'
-        choco install sqlite
-        # Note: GDAL, GEOS, PROJ installation on Windows might require vcpkg or conda
-
-    - name: Install Python dependencies
+    - name: Install Python dependencies on Ubuntu/macOS
       run: |
         python -m pip install --upgrade pip
         pip install setuptools wheel numpy pybind11
 
-    - name: Build Python extension
-      working-directory: python
+    - name: Configure pybind11 path on Ubuntu/macOS
       run: |
-        # Export pybind11 path for CMake to find it
-        export pybind11_DIR=$(python -c "import pybind11; print(pybind11.get_cmake_dir())")
-        echo "pybind11_DIR=$pybind11_DIR"
-        python setup.py build_ext --inplace
-        
-        # List built modules to verify build succeeded
-        echo "\nBuilt modules:"
-        find . -name "*.so" -o -name "*.pyd" | head -20
+        PYBIND11_DIR=$(python -c "import pybind11; print(pybind11.get_cmake_dir())")
+        echo "pybind11_DIR=$PYBIND11_DIR" >> $GITHUB_ENV
 
-    - name: Run tests
+    - name: Build extension on Ubuntu/macOS
+      run: |
+        cd python
+        python setup.py build_ext --inplace -vvv
+        find . -name "*.so" | head -20
+
+    - name: Run tests on Ubuntu/macOS
       working-directory: python
       run: |
         # Add current directory to Python path to find the built module


### PR DESCRIPTION
This pull request updates the GitHub Actions workflow for the `pylasr` project to improve cross-platform support and streamline the build and test process. The main focus is on adding macOS to the test matrix, refining dependency installation, and simplifying build steps.

**Cross-platform support and dependency management:**

* Expanded the test matrix to include both `ubuntu-latest` and `macos-latest` runners, enabling CI tests on macOS in addition to Ubuntu.
* Updated the system dependency installation step for macOS to ensure `brew update` is run and to include `libomp` and other required libraries.
* Removed the Windows-specific steps, focusing the workflow on Ubuntu and macOS for now.

**Build and test process improvements:**

* Split and clarified steps for installing Python dependencies, configuring the `pybind11` path, and building the Python extension on Ubuntu/macOS, making the process more transparent and robust.
* Adjusted testing steps to match the new platform-specific structure and ensure the built module is discoverable during test runs.