### PR TITLE
Feature request #197

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,7 @@
 # lasR 0.17.2
 
 - Fix: #198 LAS files with 0 points are discarded on-the-fly.
+- New: argument `store_in_attribute` in `local_maximum`
 
 # lasR 0.17.1
 

--- a/R/stages.R
+++ b/R/stages.R
@@ -569,6 +569,11 @@ load_matrix = function(matrix, check = TRUE)
 #' @param record_attributes The coordinates XYZ of points corresponding to the local maxima are recorded.
 #' It is also possible to record the attributes of theses points such as the intensity, return number, scan
 #' angle and so on.
+#' @param store_in_attribute In addition to producing a geospatial file with the local maxima,
+#' the points can also be flagged: 0 if the point is not a local maximum, and 1 if the
+#' point is a local maximum. If the attribute does not exist, it must first be created
+#' with \link{add_extrabyte} (see examples).
+
 #'
 #' @template param-filter
 #' @template param-ofile
@@ -587,11 +592,22 @@ load_matrix = function(matrix, check = TRUE)
 #' ans <- exec(read + chm + lmf, on = f)
 #' # terra::plot(ans$rasterize)
 #' # plot(ans$local_maximum, add = T, pch = 19)
+#'
+#' # Storing LM in UserData.
+#' lmf <- local_maximum(5, store_in_attribute = "UserData")
+#' ans <- exec(read + lmf + write_las(), on = f)
+#' ans
+#'
+#' # Storing in an new attribute without geospatial output
+#' attr <- add_extrabytes("uchar", "lm", "local maximum flag")
+#' lmf <- local_maximum(5, ofile = "", store_in_attribute = "lm")
+#' ans <- exec(attr + lmf + write_las(), on = f)
+#' ans
 #' @export
 #' @md
-local_maximum = function(ws, min_height = 2, filter = "", ofile = tempgpkg(), use_attribute = "Z", record_attributes = FALSE)
+local_maximum = function(ws, min_height = 2, filter = "", ofile = tempgpkg(), use_attribute = "Z", record_attributes = FALSE, store_in_attribute = "")
 {
-  return(.APISTAGES$local_maximum(ws, min_height, filter,  ofile, use_attribute, record_attributes))
+  return(.APISTAGES$local_maximum(ws, min_height, filter,  ofile, use_attribute, record_attributes, store_in_attribute))
 }
 
 #' @export

--- a/man/local_maximum.Rd
+++ b/man/local_maximum.Rd
@@ -11,7 +11,8 @@ local_maximum(
   filter = "",
   ofile = tempgpkg(),
   use_attribute = "Z",
-  record_attributes = FALSE
+  record_attributes = FALSE,
+  store_in_attribute = ""
 )
 
 local_maximum_raster(
@@ -49,6 +50,11 @@ the internal engine will return 0 for the missing attribute.}
 It is also possible to record the attributes of theses points such as the intensity, return number, scan
 angle and so on.}
 
+\item{store_in_attribute}{In addition to producing a geospatial file with the local maxima,
+the points can also be flagged: 0 if the point is not a local maximum, and 1 if the
+point is a local maximum. If the attribute does not exist, it must first be created
+with \link{add_extrabyte} (see examples).}
+
 \item{raster}{LASRalgorithm. A stage that produces a raster.}
 }
 \value{
@@ -73,4 +79,15 @@ lmf <- local_maximum_raster(chm, 5)
 ans <- exec(read + chm + lmf, on = f)
 # terra::plot(ans$rasterize)
 # plot(ans$local_maximum, add = T, pch = 19)
+
+# Storing LM in UserData.
+lmf <- local_maximum(5, store_in_attribute = "UserData")
+ans <- exec(read + lmf + write_las(), on = f)
+ans
+
+# Storing in an new attribute without geospatial output
+attr <- add_extrabytes("uchar", "lm", "local maximum flag")
+lmf <- local_maximum(5, ofile = "", store_in_attribute = "lm")
+ans <- exec(attr + lmf + write_las(), on = f)
+ans
 }

--- a/src/LASRapi/api.cpp
+++ b/src/LASRapi/api.cpp
@@ -175,7 +175,7 @@ Pipeline load_matrix(std::vector<double> matrix, bool check)
   return Pipeline(s);
 }
 
-Pipeline local_maximum(double ws, double min_height, std::vector<std::string> filter, std::string ofile, std::string use_attribute, bool record_attributes)
+Pipeline local_maximum(double ws, double min_height, std::vector<std::string> filter, std::string ofile, std::string use_attribute, bool record_attributes, std::string store_in_attribute)
 {
   Stage s("local_maximum");
   s.set("ws", ws);
@@ -184,6 +184,7 @@ Pipeline local_maximum(double ws, double min_height, std::vector<std::string> fi
   s.set("output", ofile);
   s.set("use_attribute", use_attribute);
   s.set("record_attributes", record_attributes);
+  s.set("store_in_attribute", store_in_attribute);
   s.set_vector();
 
   return Pipeline(s);

--- a/src/LASRapi/api.h
+++ b/src/LASRapi/api.h
@@ -145,7 +145,7 @@ Pipeline hull_triangulation(std::string connect_uid, std::string ofile = "");
 Pipeline info();
 Pipeline load_raster(std::string file, int band = 1L);
 Pipeline load_matrix(std::vector<double> matrix, bool check = true);
-Pipeline local_maximum(double ws, double min_height = 2, std::vector<std::string> filter = {""}, std::string ofile = "", std::string use_attribute = "Z", bool record_attributes = false);
+Pipeline local_maximum(double ws, double min_height = 2, std::vector<std::string> filter = {""}, std::string ofile = "", std::string use_attribute = "Z", bool record_attributes = false, std::string store_in_attribute = "");
 Pipeline local_maximum_raster(std::string connect_uid, double ws, double min_height = 2, std::vector<std::string> filter = {""}, std::string ofile = "");
 Pipeline pit_fill(std::string connect_uid, int lap_size = 3, double thr_lap = 0.1, double thr_spk = -0.1, int med_size = 3, int dil_radius = 0, std::string ofile = "");
 Pipeline rasterize(double res, double window, std::vector<std::string> operators = {"max"}, std::vector<std::string> filter = {""}, std::string ofile = "", double default_value = -99999);

--- a/src/LASRstages/localmaximum.h
+++ b/src/LASRstages/localmaximum.h
@@ -35,6 +35,7 @@ private:
   double ws;
   double min_height;
 
+  std::string attribute;
   std::string use_attribute;
   std::vector<PointLAS> lm;
 

--- a/tests/testthat/test-local_maximum.R
+++ b/tests/testthat/test-local_maximum.R
@@ -87,3 +87,26 @@ test_that("local maximum works with a raster with multiple files",
   expect_equal(nrow(u$local_maximum), 2099L)
 })
 
+test_that("local maximum can flag the points",
+{
+  f <- system.file("extdata", "MixedConifer.las", package="lasR")
+
+  # Store in 'UserData'
+  lmf <- local_maximum(5, ofile = "", store_in_attribute = "UserData")
+  ans <- exec(lmf + write_las(), on = f)
+  ans
+  res = read_las(ans)
+  expect_equal(sum(res$UserData), 177)
+
+  # Store in 'lm' but this attribute does not exist
+  lmf <- local_maximum(5, ofile = "", store_in_attribute = "lm")
+  expect_error(exec(lmf + write_las(), on = f))
+
+  # Store in 'lm' but add it first
+  attr <- add_extrabytes("uchar", "lm", "local maximum flag")
+  lmf <- local_maximum(5, ofile = "", store_in_attribute = "lm")
+  ans <- exec(attr + lmf + write_las(), on = f)
+  res = read_las(ans)
+  expect_equal(sum(res$lm), 177)
+})
+


### PR DESCRIPTION
@wiesehahn this PR adresses #197. You can install from branch `FR197` before I merge.

```r
library(lasR)
f <- system.file("extdata", "MixedConifer.las", package = "lasR")

# Store in 'UserData'
lmf <- local_maximum(5, ofile = "", store_in_attribute = "UserData")
ans <- exec(lmf + write_las(), on = f)
ans

u = lidR::readLAS(ans)
lidR::plot(u, color = "UserData", size = 3)

# Store in 'lm' but this attribute does not exist
lmf <- local_maximum(5, ofile = "", store_in_attribute = "lm")
ans <- exec(lmf + write_las(), on = f)

# Store in 'lm' but add it first
attr <- add_extrabytes("uchar", "lm", "local maximum flag")
lmf <- local_maximum(5, ofile = "", store_in_attribute = "lm")
ans <- exec(attr + lmf + write_las(), on = f)
ans

u = lidR::readLAS(ans)
lidR::plot(u, color = "lm", size = 3)
```

Since you have an attribute you can rasterize the way you suggested.

I'm checking if this does not break the `python` API before to merge.