### PR TITLE
Fix last point condition handling in run_streamed method

### DIFF
--- a/src/LASRcore/Engine.cpp
+++ b/src/LASRcore/Engine.cpp
@@ -145,7 +145,7 @@ bool Engine::run_streamed()
       // There is no point to read
       uint64_t npoints = 0;
       npoints += header->number_of_point_records;
-      if (npoints == 0) break;
+      if (npoints == 0) { last_point = true; break; }
 
       // Some stages need the header to get initialized (write_las is the only one)
       success = stage->set_header(header);

--- a/tests/testthat/test-ept.R
+++ b/tests/testthat/test-ept.R
@@ -54,11 +54,13 @@ test_that("EPT depth filtering works",
 {
   ept <- system.file("extdata", "ept-test-multi", "ept.json", package = "lasR")
 
-  # Test data has only depth-1 tiles, so depth=1 should match full read
-  d1 <- exec(reader(depth = 1) + summarise(), on = ept)
+  # Test data has no 0-0-0-0 tile (hierarchy starts at depth 1), so depth=0
+  # yields zero points and must not hang.
+  d0 <- exec(reader(depth = 0) + summarise(), on = ept)
   full <- exec(reader() + summarise(), on = ept)
 
-  expect_equal(d1$npoints, full$npoints)
+  expect_equal(d0$npoints, 0)
+  expect_gt(full$npoints, 0)
 })
 
 test_that("Multiple EPT endpoints produce an error",


### PR DESCRIPTION
Closes #290 

Looks like the problem already existed.
Tested with depth=0, works now.