### PR TITLE
Size COPC octree from union bbox when merging multiple inputs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,5 @@ python/build
 *.a
 *.pyc
 CLAUDE.md
+*settings.json
+*DS_Store*

--- a/benchmarks/copc/.gitignore
+++ b/benchmarks/copc/.gitignore
@@ -1,0 +1,13 @@
+# downloaded inputs and runtime outputs are not committed
+data/*
+!data/.gitkeep
+results/*
+!results/.gitkeep
+!results/outputs/
+results/outputs/*
+!results/outputs/.gitkeep
+!results/logs/
+results/logs/*
+!results/logs/.gitkeep
+potree_viewer/*
+*DS_Store*

--- a/src/LASRcore/COPChierarchy.cpp
+++ b/src/LASRcore/COPChierarchy.cpp
@@ -3,6 +3,7 @@
 #include "print.h"
 
 #include <algorithm>
+#include <cmath>
 #include <cstring>
 #include <functional>
 #include <limits>
@@ -28,6 +29,28 @@ EPTkey COPChierarchy::compute_key_at(const LASpoint* p, I32 depth) const
 I32 COPChierarchy::compute_voxel_cell(const LASpoint* p, const EPTkey& key) const
 {
   return octree.get_cell(p, key);
+}
+
+I32 COPChierarchy::compute_xy_cell(const LASpoint* p, const EPTkey& key, I32 xy_grid_size) const
+{
+  if (xy_grid_size < 2) xy_grid_size = octree.get_gridsize();
+  if (xy_grid_size < 2) return -1;
+
+  const F64 size = octree.get_halfsize() * 2.0;
+  const F64 octant_size = std::ldexp(size, -key.d);
+  if (!(octant_size > 0.0)) return -1;
+
+  const F64 minx = octant_size * key.x + (octree.get_center_x() - octree.get_halfsize());
+  const F64 miny = octant_size * key.y + (octree.get_center_y() - octree.get_halfsize());
+  const F64 grid_resolution = octant_size / xy_grid_size;
+  if (!(grid_resolution > 0.0)) return -1;
+
+  I32 xi = (I32)std::floor((p->get_x() - minx) / grid_resolution);
+  I32 yi = (I32)std::floor((p->get_y() - miny) / grid_resolution);
+  xi = (std::min)((std::max)(0, xi), xy_grid_size - 1);
+  yi = (std::min)((std::max)(0, yi), xy_grid_size - 1);
+
+  return yi * xy_grid_size + xi;
 }
 
 // Find the nearest existing ancestor of `key` in `octant_counts`. Returns

--- a/src/LASRcore/COPChierarchy.h
+++ b/src/LASRcore/COPChierarchy.h
@@ -48,6 +48,12 @@ public:
   // a non-negative cell id usable as a key into a per-octant occupancy set.
   I32 compute_voxel_cell(const LASpoint* p, const EPTkey& key) const;
 
+  // XY-only cell index within `key`'s xy_grid_size² grid. Used by the
+  // streaming COPC writer for low-depth overview chunks where map-view
+  // visual balance matters more than vertical occupancy. Returns a
+  // non-negative cell id usable in the same occupancy table as voxel cells.
+  I32 compute_xy_cell(const LASpoint* p, const EPTkey& key, I32 xy_grid_size) const;
+
   I32 get_max_depth() const { return max_depth; }
   I32 get_grid_size() const { return octree.get_gridsize(); }
 

--- a/src/LASRcore/COPCwriter.cpp
+++ b/src/LASRcore/COPCwriter.cpp
@@ -505,6 +505,18 @@ bool COPCwriter::open(const char* file_name, const LASheader* source_header, I32
   if (std::uint64_t e = env_max_sort_memory(); e > 0) max_sort_memory = e;
   if (std::uint32_t e = env_max_entries_per_page(); e > 0) max_entries_per_page = e;
   if (int e = env_protected_lod_depth(); e >= 0) protected_lod_depth = e;
+  // Auto-tune xy_lod_depth to (routing_max_depth - 1) — i.e. one level
+  // above the leaf — so XY-LOD reopen-on-flush covers every intermediate
+  // (non-leaf) depth regardless of how deep the tree ends up. Without
+  // this, merged writes whose routing_max_depth exceeds the static
+  // default+1 (= 5) leave intermediate octants flushed-and-not-reopened,
+  // producing visible horizontal banding at d > xy_lod_depth (e.g. d=5
+  // of a 4-tile merge with routing_max_depth=6). routing_max_depth has
+  // already been resolved above (auto = max_depth + max_extra_depth, or
+  // user-set value, or HARD_DEPTH_LIMIT). The single-tile case
+  // (routing_max_depth=5 → xy_lod_depth=4) matches the previous static
+  // default, so behavior there is unchanged. Env override still wins.
+  xy_lod_depth = (std::max)(0, routing_max_depth - 1);
   if (int e = env_xy_lod_depth(); e >= -1) xy_lod_depth = e;
   if (int e = env_xy_lod_grid_multiplier(); e > 0) xy_lod_grid_multiplier = e;
 

--- a/src/LASRcore/COPCwriter.cpp
+++ b/src/LASRcore/COPCwriter.cpp
@@ -91,6 +91,17 @@ namespace
     if (!end || *end != '\0' || n == 0 || n > 0xFFFFFFFFu) return 0;
     return (std::uint32_t)n;
   }
+  int env_protected_lod_depth()
+  {
+    const char* v = std::getenv("LASR_COPC_PROTECTED_LOD_DEPTH");
+    if (!v || !*v) return -1;
+    char* end = nullptr;
+    long n = std::strtol(v, &end, 10);
+    if (!end || *end != '\0') return -1;
+    if (n < -1) return -1;
+    if (n > 16) return 16;
+    return (int)n;
+  }
 
   // Extract the three fields (GPS time, scanner channel, return number) used
   // as the within-chunk sort key. Layout matches PDRF 6/7/8 point records.
@@ -472,6 +483,7 @@ bool COPCwriter::open(const char* file_name, const LASheader* source_header, I32
   // budget partition.
   if (std::uint64_t e = env_max_sort_memory(); e > 0) max_sort_memory = e;
   if (std::uint32_t e = env_max_entries_per_page(); e > 0) max_entries_per_page = e;
+  if (int e = env_protected_lod_depth(); e >= 0) protected_lod_depth = e;
 
   // Optional one-shot diagnostic: when LASR_COPC_DEBUG_BUDGETS is set,
   // print the resolved (resident, ram, wb, sort-cap) so tests and operators
@@ -480,11 +492,12 @@ bool COPCwriter::open(const char* file_name, const LASheader* source_header, I32
   // public R API.
   if (const char* dbg = std::getenv("LASR_COPC_DEBUG_BUDGETS"); dbg && *dbg)
   {
-    warning("COPC budgets resolved: resident=%llu spill_ram=%llu spill_wb=%llu sort_cap=%llu (mem=%llu)\n",
+    warning("COPC budgets resolved: resident=%llu spill_ram=%llu spill_wb=%llu sort_cap=%llu protected_lod_depth=%d (mem=%llu)\n",
             (unsigned long long)resident_budget,
             (unsigned long long)spill_ram,
             (unsigned long long)spill_wb,
             (unsigned long long)max_sort_memory,
+            (int)protected_lod_depth,
             (unsigned long long)mem_budget);
   }
 
@@ -833,8 +846,8 @@ bool COPCwriter::flush_hot_octant(const EPTkey& key)
 
 bool COPCwriter::enforce_resident_budget()
 {
-  // Pick the heaviest hot octant from the incrementally-maintained
-  // octant_bytes table (O(N_octants), no inner voxel sum) and flush.
+  // Pick the heaviest unprotected hot octant from the incrementally-
+  // maintained octant_bytes table (O(N_octants), no inner voxel sum) and flush.
   // Drive resident_bytes below the LOW WATER mark (50% of budget) before
   // returning, so we don't get called again on the very next insert
   // — without hysteresis the previous version triggered per-point on
@@ -864,12 +877,30 @@ bool COPCwriter::enforce_resident_budget()
   // entire write because hysteresis prevents re-trigger on each insert.
   // Low_water at 40% (was 50%) leaves an extra 10% as headroom for
   // metadata, fragmentation, and transient peaks during finalize.
-  const std::uint64_t low_water = (std::uint64_t)((double)resident_budget * 0.4);
-  if (resident_bytes <= low_water || octant_bytes.empty()) return true;
+  // Shallow LODs are intentionally not flush candidates: freezing them
+  // early makes later points descend past those overview octants, so
+  // low-depth reads can show scan-order bands and blocky holes. Treat
+  // protected bytes as the irreducible floor and apply hysteresis to the
+  // remaining budget slice.
+  if (octant_bytes.empty()) return true;
+  std::uint64_t protected_bytes = 0;
+  for (const auto& kv : octant_bytes)
+    if (kv.first.d <= protected_lod_depth) protected_bytes += kv.second;
+
+  const std::uint64_t unprotected_budget =
+      (resident_budget > protected_bytes) ? (resident_budget - protected_bytes) : 0;
+  const std::uint64_t low_water =
+      protected_bytes + (std::uint64_t)((double)unprotected_budget * 0.4);
+  if (resident_bytes <= low_water) return true;
 
   std::vector<std::pair<std::uint64_t, EPTkey>> sorted;
   sorted.reserve(octant_bytes.size());
-  for (const auto& kv : octant_bytes) sorted.emplace_back(kv.second, kv.first);
+  for (const auto& kv : octant_bytes)
+  {
+    if (kv.first.d <= protected_lod_depth) continue;
+    sorted.emplace_back(kv.second, kv.first);
+  }
+  if (sorted.empty()) return true;
   // Heaviest first; (depth, x, y, z) tie-break preserves determinism.
   std::sort(sorted.begin(), sorted.end(),
             [&key_less](const auto& a, const auto& b) {

--- a/src/LASRcore/COPCwriter.cpp
+++ b/src/LASRcore/COPCwriter.cpp
@@ -102,6 +102,27 @@ namespace
     if (n > 16) return 16;
     return (int)n;
   }
+  int env_xy_lod_depth()
+  {
+    const char* v = std::getenv("LASR_COPC_XY_LOD_DEPTH");
+    if (!v || !*v) return -2;
+    char* end = nullptr;
+    long n = std::strtol(v, &end, 10);
+    if (!end || *end != '\0') return -2;
+    if (n < -1) return -2;
+    if (n > 16) return 16;
+    return (int)n;
+  }
+  int env_xy_lod_grid_multiplier()
+  {
+    const char* v = std::getenv("LASR_COPC_XY_LOD_GRID_MULTIPLIER");
+    if (!v || !*v) return 0;
+    char* end = nullptr;
+    long n = std::strtol(v, &end, 10);
+    if (!end || *end != '\0' || n <= 0) return 0;
+    if (n > 16) return 16;
+    return (int)n;
+  }
 
   // Extract the three fields (GPS time, scanner channel, return number) used
   // as the within-chunk sort key. Layout matches PDRF 6/7/8 point records.
@@ -484,6 +505,8 @@ bool COPCwriter::open(const char* file_name, const LASheader* source_header, I32
   if (std::uint64_t e = env_max_sort_memory(); e > 0) max_sort_memory = e;
   if (std::uint32_t e = env_max_entries_per_page(); e > 0) max_entries_per_page = e;
   if (int e = env_protected_lod_depth(); e >= 0) protected_lod_depth = e;
+  if (int e = env_xy_lod_depth(); e >= -1) xy_lod_depth = e;
+  if (int e = env_xy_lod_grid_multiplier(); e > 0) xy_lod_grid_multiplier = e;
 
   // Optional one-shot diagnostic: when LASR_COPC_DEBUG_BUDGETS is set,
   // print the resolved (resident, ram, wb, sort-cap) so tests and operators
@@ -492,12 +515,14 @@ bool COPCwriter::open(const char* file_name, const LASheader* source_header, I32
   // public R API.
   if (const char* dbg = std::getenv("LASR_COPC_DEBUG_BUDGETS"); dbg && *dbg)
   {
-    warning("COPC budgets resolved: resident=%llu spill_ram=%llu spill_wb=%llu sort_cap=%llu protected_lod_depth=%d (mem=%llu)\n",
+    warning("COPC budgets resolved: resident=%llu spill_ram=%llu spill_wb=%llu sort_cap=%llu protected_lod_depth=%d xy_lod_depth=%d xy_lod_grid_multiplier=%d (mem=%llu)\n",
             (unsigned long long)resident_budget,
             (unsigned long long)spill_ram,
             (unsigned long long)spill_wb,
             (unsigned long long)max_sort_memory,
             (int)protected_lod_depth,
+            (int)xy_lod_depth,
+            (int)xy_lod_grid_multiplier,
             (unsigned long long)mem_budget);
   }
 
@@ -649,6 +674,41 @@ void COPCwriter::FlatI32U32Map::insert(I32 cell, U32 idx)
   ++count;
 }
 
+bool COPCwriter::FlatI32U32Map::erase(I32 cell)
+{
+  if (keys.empty()) return false;
+  const U32 mask = static_cast<U32>(keys.size() - 1);
+  U32 slot = mix(cell) & mask;
+  for (;;)
+  {
+    const I32 k = keys[slot];
+    if (k == -1) return false;
+    if (k == cell) break;
+    slot = (slot + 1u) & mask;
+  }
+
+  keys[slot] = -1;
+  values[slot] = 0u;
+  --count;
+
+  // Linear-probing deletion must reinsert the following cluster; otherwise
+  // find() could stop at the new empty slot before reaching keys displaced
+  // past it.
+  U32 next = (slot + 1u) & mask;
+  while (keys[next] != -1)
+  {
+    const I32 rekey = keys[next];
+    const U32 reval = values[next];
+    keys[next] = -1;
+    values[next] = 0u;
+    --count;
+    insert(rekey, reval);
+    next = (next + 1u) & mask;
+  }
+
+  return true;
+}
+
 // Small per-voxel slack added on top of the capacity-delta accounting.
 // With the FlatI32U32Map (no per-entry node allocations) the only
 // non-array per-voxel cost is the malloc bookkeeping amortised across
@@ -684,10 +744,34 @@ bool COPCwriter::route_or_spill(U8* bytes, U64 hash, I32 start_depth)
     {
       EPTkey k_d = hierarchy->compute_key_at(point, d);
 
-      // Flushed octants no longer accept claims — descend.
-      if (flushed_octants.count(k_d)) continue;
+      // Flushed non-XY octants no longer accept claims — descend. For
+      // intermediate XY overview octants, a flush is only a byte spill:
+      // keep accepting later batches until the total emitted count reaches
+      // the chunk cap. That keeps point RAM bounded but avoids freezing a
+      // low-depth chunk to whichever scan band arrived before the first
+      // memory-pressure flush.
+      const bool was_flushed = flushed_octants.count(k_d) != 0;
+      U64 already_flushed = 0;
+      if (was_flushed)
+      {
+        if (d > xy_lod_depth) continue;
+        auto fit = flushed_octant_points.find(k_d);
+        already_flushed = (fit != flushed_octant_points.end()) ? fit->second : 0;
+        if (already_flushed >= (U64)cap) continue;
+      }
 
-      I32 cell_d = hierarchy->compute_voxel_cell(point, k_d);
+      I32 cell_d = -1;
+      if (d <= xy_lod_depth)
+      {
+        const I32 base_grid = hierarchy->get_grid_size();
+        const I32 multiplier = (std::max)(1, xy_lod_grid_multiplier);
+        const I32 xy_grid = (base_grid <= 8192 / multiplier) ? base_grid * multiplier : 8192;
+        cell_d = hierarchy->compute_xy_cell(point, k_d, xy_grid);
+      }
+      else
+      {
+        cell_d = hierarchy->compute_voxel_cell(point, k_d);
+      }
       if (cell_d < 0) continue;
 
       auto& oct = occupancy[k_d];
@@ -695,8 +779,36 @@ bool COPCwriter::route_or_spill(U8* bytes, U64 hash, I32 start_depth)
       if (found_idx == UINT32_MAX)
       {
         // Voxel free. Claim it only if the octant still has cap room;
-        // otherwise descend further (chunk-size cap).
-        if ((I32)oct.cells.size() >= cap) continue;
+        // otherwise let shallow XY overview cells compete for an existing
+        // slot. This avoids freezing the first cap cells encountered in
+        // scan order at d=3-4: a later cell with a stronger deterministic
+        // hash can evict a previously selected cell, and the evicted point
+        // continues routing downward. The slot count and byte capacity stay
+        // unchanged, so this improves intermediate-depth mixing without
+        // increasing resident RAM.
+        const U64 total_claims = already_flushed + (U64)oct.cells.size();
+        if (total_claims >= (U64)cap)
+        {
+          if (d <= xy_lod_depth && !oct.cells.empty())
+          {
+            const U32 idx = (U32)(hash % (U64)oct.cells.size());
+            if (hash > oct.hashes[idx])
+            {
+              const I32 old_cell = oct.cells[idx];
+              U8* slot = oct.bytes.data() + (std::size_t)idx * point_size;
+              std::swap_ranges(bytes, bytes + point_size, slot);
+              std::swap(hash, oct.hashes[idx]);
+              oct.cell_to_idx.erase(old_cell);
+              oct.cells[idx] = cell_d;
+              oct.cell_to_idx.insert(cell_d, idx);
+              start_depth = d + 1;
+              placed = false;
+              need_decode = true;
+              goto next_iter;
+            }
+          }
+          continue;
+        }
         // Snapshot capacities before insertion so we can attribute any
         // vector growth (which doubles capacity) to this voxel's account.
         // Includes the FlatI32U32Map's two arrays.
@@ -838,6 +950,7 @@ bool COPCwriter::flush_hot_octant(const EPTkey& key)
   auto bb_it = octant_bytes.find(key);
   const std::size_t freed = (bb_it != octant_bytes.end()) ? bb_it->second : 0;
   if (bb_it != octant_bytes.end()) octant_bytes.erase(bb_it);
+  flushed_octant_points[key] += (U64)n;
   occupancy.erase(it);
   flushed_octants.insert(key);
   resident_bytes = (resident_bytes >= freed) ? (resident_bytes - freed) : 0;
@@ -846,13 +959,11 @@ bool COPCwriter::flush_hot_octant(const EPTkey& key)
 
 bool COPCwriter::enforce_resident_budget()
 {
-  // Pick the heaviest unprotected hot octant from the incrementally-
-  // maintained octant_bytes table (O(N_octants), no inner voxel sum) and flush.
-  // Drive resident_bytes below the LOW WATER mark (50% of budget) before
-  // returning, so we don't get called again on the very next insert
-  // — without hysteresis the previous version triggered per-point on
-  // huge inputs and dominated CPU (97% in this function on the sofi
-  // run before this fix).
+  // Pick the heaviest unprotected hot octants from the incrementally-
+  // maintained octant_bytes table (O(N_octants), no inner voxel sum) and
+  // flush until resident_bytes drops below the low-water mark. Without any
+  // hysteresis the previous version triggered per-point on huge inputs and
+  // dominated CPU (97% in this function on the sofi run before this fix).
   //
   // Tie-break on (depth, x, y, z) when multiple octants share the
   // heaviest size: flushing freezes that octant's voxel decisions and
@@ -875,9 +986,9 @@ bool COPCwriter::enforce_resident_budget()
   // Snapshot+sort once, then drain from heaviest until under low_water.
   // O(N log N) per call; typically called only a handful of times for an
   // entire write because hysteresis prevents re-trigger on each insert.
-  // Low_water at 40% (was 50%) leaves an extra 10% as headroom for
-  // metadata, fragmentation, and transient peaks during finalize.
-  // Shallow LODs are intentionally not flush candidates: freezing them
+  // Low_water at 40% leaves headroom for metadata, fragmentation, and
+  // transient peaks during finalize.
+  // Protected LODs are intentionally not flush candidates: freezing them
   // early makes later points descend past those overview octants, so
   // low-depth reads can show scan-order bands and blocky holes. Treat
   // protected bytes as the irreducible floor and apply hysteresis to the
@@ -911,7 +1022,8 @@ bool COPCwriter::enforce_resident_budget()
   for (const auto& kv : sorted)
   {
     if (resident_bytes <= low_water) break;
-    if (kv.first == 0) break;
+    // Defensive: skip if the octant was already drained earlier this pass.
+    if (occupancy.find(kv.second) == occupancy.end()) continue;
     if (!flush_hot_octant(kv.second)) return false;
   }
   return true;

--- a/src/LASRcore/COPCwriter.h
+++ b/src/LASRcore/COPCwriter.h
@@ -220,6 +220,12 @@ private:
   I32 copc_density = 256;
   I32 max_points_per_octant = 100000; // used to estimate auto max_depth
   I32 min_points_per_chunk = 100;
+  // Shallow overview octants are kept replaceable until finalization so
+  // low-depth COPC reads sample the whole input stream instead of whatever
+  // spatial band happened to arrive before the resident budget first flushed.
+  // Internal/operator knob only: LASR_COPC_PROTECTED_LOD_DEPTH can lower this
+  // to 0/1 for tighter memory or raise it to 3 while tuning visualization.
+  I32 protected_lod_depth = 2;
   // Hard upper bound on adaptive depth bumping. Only consulted when
   // copc_depth was left at its auto sentinel (-1) at open() time — a user
   // who explicitly passed max_depth gets that value as a hard routing cap

--- a/src/LASRcore/COPCwriter.h
+++ b/src/LASRcore/COPCwriter.h
@@ -126,9 +126,7 @@ private:
   // via the caller-passed buffer.
   //
   // FlatI32U32Map is an open-addressed I32→U32 hash table specialised
-  // for our usage: insert-or-update only (no per-entry erase — the
-  // whole octant is dropped at flush time), so we don't need
-  // tombstones; the cell-id key is non-negative so we sentinel empty
+  // for our usage. The cell-id key is non-negative so we sentinel empty
   // slots with -1; capacity is a power of 2 so slot index is a cheap
   // bitmask. ~12 B amortised per entry vs ~50 B for unordered_map.
   struct FlatI32U32Map
@@ -147,6 +145,11 @@ private:
     // Insert (cell -> idx) assuming cell is not already present. Grows
     // the table when load factor would exceed ~0.7.
     void insert(I32 cell, U32 idx);
+
+    // Erase a cell mapping if present. Used by shallow XY cap replacement,
+    // where a full overview octant keeps the same slot count but swaps a
+    // previously selected cell for a later competing cell.
+    bool erase(I32 cell);
   };
 
   struct HotOctant
@@ -167,12 +170,17 @@ private:
   std::unordered_map<EPTkey, HotOctant, EPTKeyHasher> occupancy;
 
   // Octants whose residents have already been flushed to spill due to RAM
-  // pressure. A flushed octant no longer accepts new claims at routing
-  // time — points descend past it. The flushed residents are baked into
-  // spill exactly as if they had been emitted from the in-RAM table
-  // normally; they just lose their replaceability (the hash-replace
-  // mechanism is disabled for that octant after flush).
+  // pressure. Non-XY flushed octants no longer accept new claims at routing
+  // time — points descend past them. Intermediate XY flushed octants may
+  // reopen for later batches up to the chunk cap, using
+  // flushed_octant_points to keep the total bounded.
   std::unordered_set<EPTkey, EPTKeyHasher> flushed_octants;
+
+  // Point counts already appended for flushed octants. For intermediate XY
+  // overview depths we can reopen a flushed octant for later batches until
+  // its total emitted count reaches max_points_per_octant. This keeps the
+  // same resident byte cap while avoiding a permanent scan-order snapshot.
+  std::unordered_map<EPTkey, U64, EPTKeyHasher> flushed_octant_points;
 
   // Per-octant byte usage, kept in sync with `occupancy` on every insert /
   // replace / evict / flush. Avoids the O(voxels) cost of re-summing each
@@ -224,8 +232,15 @@ private:
   // low-depth COPC reads sample the whole input stream instead of whatever
   // spatial band happened to arrive before the resident budget first flushed.
   // Internal/operator knob only: LASR_COPC_PROTECTED_LOD_DEPTH can lower this
-  // to 0/1 for tighter memory or raise it to 3 while tuning visualization.
+  // to 0/1 for tighter memory or raise it to 3/4 while tuning visualization.
   I32 protected_lod_depth = 2;
+  // Low-depth overview chunks are sampled in map space (XY) instead of full
+  // 3D voxel space. This avoids scan/height structure showing up as bands in
+  // coarse COPC reads. LASR_COPC_XY_LOD_DEPTH=-1 disables; the multiplier
+  // controls the XY grid resolution relative to copc_density.
+  I32 xy_lod_depth = 4;
+  I32 xy_lod_grid_multiplier = 2;
+
   // Hard upper bound on adaptive depth bumping. Only consulted when
   // copc_depth was left at its auto sentinel (-1) at open() time — a user
   // who explicitly passed max_depth gets that value as a hard routing cap

--- a/src/LASRcore/FileCollection.cpp
+++ b/src/LASRcore/FileCollection.cpp
@@ -656,6 +656,8 @@ bool FileCollection::add_header(const Header& header, bool noprocess)
   if (ymin > header.min_y) ymin = header.min_y;
   if (xmax < header.max_x) xmax = header.max_x;
   if (ymax < header.max_y) ymax = header.max_y;
+  if (zmin > header.min_z) zmin = header.min_z;
+  if (zmax < header.max_z) zmax = header.max_z;
 
   this->noprocess.push_back(noprocess);
   this->file_index.add(header.min_x, header.min_y, header.max_x, header.max_y);
@@ -938,8 +940,10 @@ void FileCollection::clear()
 {
   xmin = std::numeric_limits<double>::max();
   ymin = std::numeric_limits<double>::max();
+  zmin = std::numeric_limits<double>::max();
   xmax = -std::numeric_limits<double>::max();
   ymax = -std::numeric_limits<double>::max();
+  zmax = -std::numeric_limits<double>::max();
   last_error.clear();
 
   use_dataframe = true;

--- a/src/LASRcore/FileCollection.cpp
+++ b/src/LASRcore/FileCollection.cpp
@@ -234,7 +234,11 @@ bool FileCollection::read_vpc(const std::string& filename)
         file_path = std::filesystem::weakly_canonical(parent_folder / file_path).string();
       }
 
-      int pccount = feature["properties"]["pc:count"].get<int>();
+      // pc:count via 64-bit. STAC's pointcloud extension says the field is
+      // an integer with no upper bound; reading as int silently truncates
+      // catalogs over ~2.1B points, which would mis-size the merged COPC
+      // octree's auto max_depth.
+      uint64_t pccount = feature["properties"]["pc:count"].get<uint64_t>();
 
       // Get the CRS either in WKT or EPSG
       std::string wkt = feature["properties"].value("proj:wkt2", "");
@@ -507,7 +511,19 @@ bool FileCollection::write_vpc(const std::string& vpcfile, const CRS& crs, bool 
     output << "      \"pc:count\": " << n << "," << std::endl;;
     output << "      \"pc:type\": " << "\"lidar\"" << ","<< std::endl;
     if (index) output << "      \"index:indexed\": " << "true," << std::endl;
-    output << "      \"proj:bbox\": [" << std::fixed << std::setprecision(3) << bbox.minx << ", " << bbox.miny << ", " << bbox.maxx << ", " << bbox.maxy << "],"<< std::endl;
+    // 6-element STAC proj:bbox = [minx, miny, minz, maxx, maxy, maxz]. The
+    // older 4-element form is allowed by the spec but loses z, and lasR's
+    // own VPC reader (read_vpc) only inspects properties.proj:bbox — not
+    // the top-level "bbox" field — when populating the FileCollection's
+    // 3D bounds. A 4D properties.proj:bbox round-tripped into a merged
+    // COPC write produces no z bounds, which then disables the union
+    // bbox/count override on the writer side and falls back to file-1's
+    // bbox alone.
+    output << "      \"proj:bbox\": ["
+           << std::fixed << std::setprecision(3)
+           << bbox.minx << ", " << bbox.miny << ", " << zmin << ", "
+           << bbox.maxx << ", " << bbox.maxy << ", " << zmax
+           << "]," << std::endl;
     if (!wkt.empty()) output << "      \"proj:wkt2\": " << wkt;
     if (epsg != 0) output << "," << std::endl << "      \"proj:epsg\": " << epsg << std::endl;
     output << "    }," << std::endl;

--- a/src/LASRcore/FileCollection.cpp
+++ b/src/LASRcore/FileCollection.cpp
@@ -253,15 +253,23 @@ bool FileCollection::read_vpc(const std::string& filename)
         // # nocov end
       }
 
-      // We are sure there is a bbox
+      // We are sure there is a bbox. STAC proj:bbox is [minx,miny,minz,maxx,maxy,maxz]
+      // for 3D and [minx,miny,maxx,maxy] for 2D. Read z when available so the
+      // FileCollection's union z-bounds are tight; merged COPC outputs need all
+      // three axes to size the octree correctly.
       auto bbox = feature["properties"]["proj:bbox"];
       double min_x, min_y, max_x, max_y;
+      double min_z = 0.0, max_z = 0.0;
+      bool have_z = false;
       if (bbox.size() == 6)
       {
         min_x = bbox[0].get<double>();
         min_y = bbox[1].get<double>();
+        min_z = bbox[2].get<double>();
         max_x = bbox[3].get<double>();
         max_y = bbox[4].get<double>();
+        max_z = bbox[5].get<double>();
+        have_z = true;
       }
       else if (bbox.size() == 4)
       {
@@ -283,6 +291,11 @@ bool FileCollection::read_vpc(const std::string& filename)
       h.min_y = min_y;
       h.max_x = max_x;
       h.max_y = max_y;
+      if (have_z)
+      {
+        h.min_z = min_z;
+        h.max_z = max_z;
+      }
       h.number_of_point_records = pccount;
       h.spatial_index = spatial_index;
       h.signature = "LASF";
@@ -298,6 +311,11 @@ bool FileCollection::read_vpc(const std::string& filename)
       if (ymin > h.min_y) ymin = h.min_y;
       if (xmax < h.max_x) xmax = h.max_x;
       if (ymax < h.max_y) ymax = h.max_y;
+      if (have_z)
+      {
+        if (zmin > h.min_z) zmin = h.min_z;
+        if (zmax < h.max_z) zmax = h.max_z;
+      }
     }
   }
   catch (const std::ifstream::failure& e)
@@ -1022,6 +1040,13 @@ PathType FileCollection::parse_path(const std::string& path)
   }
 }
 
+
+uint64_t FileCollection::get_total_points() const
+{
+  uint64_t total = 0;
+  for (const Header& h : headers) total += h.number_of_point_records;
+  return total;
+}
 
 FileCollection::FileCollection()
 {

--- a/src/LASRcore/FileCollection.cpp
+++ b/src/LASRcore/FileCollection.cpp
@@ -199,6 +199,14 @@ bool FileCollection::read_vpc(const std::string& filename)
       return false; // # nocov
     }
 
+    // Track whether every feature provides a 3D bbox. If some do and
+    // some don't, the catalog's accumulated z-bounds would only cover
+    // a subset of files while point counts cover all of them — this
+    // produces a wrong octree size on merged COPC writes. Reject the
+    // mix loudly instead of silently producing skewed output.
+    int n_features_with_z = 0;
+    int n_features_total = 0;
+
     // Loop over the features to read the file paths and bounding boxes
     for (const auto& feature : vpc["features"])
     {
@@ -319,7 +327,21 @@ bool FileCollection::read_vpc(const std::string& filename)
       {
         if (zmin > h.min_z) zmin = h.min_z;
         if (zmax < h.max_z) zmax = h.max_z;
+        n_features_with_z++;
       }
+      n_features_total++;
+    }
+
+    if (n_features_with_z != 0 && n_features_with_z != n_features_total)
+    {
+      last_error = "Malformed virtual point cloud file: " +
+        std::to_string(n_features_with_z) + " of " +
+        std::to_string(n_features_total) + " features carry a 3D proj:bbox; "
+        "the rest are 2D. Mixed 4D/6D bboxes produce a partial z range over "
+        "only some inputs while point counts cover all of them, which sizes "
+        "the merged COPC octree incorrectly. Make every feature's "
+        "properties.proj:bbox 6-element [minx, miny, minz, maxx, maxy, maxz].";
+      return false;
     }
   }
   catch (const std::ifstream::failure& e)
@@ -470,11 +492,19 @@ bool FileCollection::write_vpc(const std::string& vpcfile, const CRS& crs, bool 
     oTargetSRS.SetAxisMappingStrategy(OAMS_TRADITIONAL_GIS_ORDER);
     oSourceSRS = crs.get_crs();
     OGRCoordinateTransformation *poTransform = OGRCreateCoordinateTransformation(&oSourceSRS, &oTargetSRS);
-    double z = 0;
-    if (!poTransform->Transform(1, &A.x, &A.y, &zmin) ||
-        !poTransform->Transform(1, &B.x, &B.y, &z) ||
-        !poTransform->Transform(1, &C.x, &C.y, &zmax) ||
-        !poTransform->Transform(1, &D.x, &D.y, &z))
+    // STAC's top-level "bbox" lives in WGS 84 (EPSG:4979). Transform a
+    // mutable copy of the source z so the source-CRS z values stay
+    // available for properties.proj:bbox below — feeding the transformed
+    // values into proj:bbox while x/y are kept in source coords would
+    // make proj:bbox internally inconsistent if the vertical transform
+    // shifts z.
+    double top_zmin = zmin;
+    double top_zmax = zmax;
+    double z_throwaway = 0;
+    if (!poTransform->Transform(1, &A.x, &A.y, &top_zmin) ||
+        !poTransform->Transform(1, &B.x, &B.y, &z_throwaway) ||
+        !poTransform->Transform(1, &C.x, &C.y, &top_zmax) ||
+        !poTransform->Transform(1, &D.x, &D.y, &z_throwaway))
     {
       last_error = "Transformation of the bounding in WGS 84 failed!";
       return false;
@@ -483,7 +513,7 @@ bool FileCollection::write_vpc(const std::string& vpcfile, const CRS& crs, bool 
     char buffer[1024];
     snprintf(buffer, sizeof(buffer), "[ [%.9lf,%.9lf], [%.9lf,%.9lf], [%.9lf,%.9lf], [%.9lf,%.9lf], [%.9lf,%.9lf] ]", A.x, A.y, B.x, B.y, C.x, C.y, D.x, D.y, A.x, A.y);
     std::string geometry(buffer);
-    snprintf(buffer, sizeof(buffer), "[%.9lf, %.9lf, %.3lf, %.9lf, %.9lf, %.3lf]", MIN(A.x, D.x), MIN(A.y, B.y), zmin, MAX(B.x, C.x), MAX(C.y, D.y), zmax);
+    snprintf(buffer, sizeof(buffer), "[%.9lf, %.9lf, %.3lf, %.9lf, %.9lf, %.3lf]", MIN(A.x, D.x), MIN(A.y, B.y), top_zmin, MAX(B.x, C.x), MAX(C.y, D.y), top_zmax);
     std::string sbbox(buffer);
 
     std::string id = file.stem().string();

--- a/src/LASRcore/FileCollection.h
+++ b/src/LASRcore/FileCollection.h
@@ -49,8 +49,10 @@ public:
   double get_buffer() const { return buffer; };
   double get_xmin() const { return xmin; };
   double get_ymin() const { return ymin; };
+  double get_zmin() const { return zmin; };
   double get_xmax() const { return xmax; };
   double get_ymax() const { return ymax; };
+  double get_zmax() const { return zmax; };
   void set_crs(const CRS& crs) { this->crs = crs; };
   CRS get_crs() const { return crs; };
   const std::vector<std::filesystem::path>& get_files() const;
@@ -79,8 +81,10 @@ private:
   // Bounding box of the file collection
   double xmin;
   double ymin;
+  double zmin;
   double xmax;
   double ymax;
+  double zmax;
 
   // CRS retained of the overall collection
   CRS crs;

--- a/src/LASRcore/FileCollection.h
+++ b/src/LASRcore/FileCollection.h
@@ -53,6 +53,11 @@ public:
   double get_xmax() const { return xmax; };
   double get_ymax() const { return ymax; };
   double get_zmax() const { return zmax; };
+  // Total number of points across every header in the collection. Used by
+  // the COPC writer to size the octree's auto max_depth correctly when
+  // merging multiple files into a single output (the per-tile header count
+  // alone is too small).
+  uint64_t get_total_points() const;
   void set_crs(const CRS& crs) { this->crs = crs; };
   CRS get_crs() const { return crs; };
   const std::vector<std::filesystem::path>& get_files() const;

--- a/src/LASRstages/writelas.cpp
+++ b/src/LASRstages/writelas.cpp
@@ -301,7 +301,25 @@ bool LASRlaswriter::set_header(Header*& header)
   // its own bbox/count — applying the catalog values there would inflate
   // every per-tile output to cover the whole input set. Non-COPC writes
   // ignore both fields at open anyway, but skip the override for clarity.
-  if (catalog_bbox_valid && merged && path_has_copc_suffix(template_filename))
+  const bool merged_copc = merged && path_has_copc_suffix(template_filename);
+  if (merged_copc && !catalog_bbox_valid)
+  {
+    // Catalog bbox is invalid (typically: legacy 4D-only VPC where the
+    // reader couldn't recover z bounds; or no FileCollection seen). With
+    // a missing catalog bbox, set_header would silently fall back to
+    // file-1's per-tile bbox/count — sizing the merged COPC's octree
+    // and auto-depth from a single tile, which produces a structurally
+    // bad output (clamping at close, too-shallow depth). Refuse loudly
+    // so the user fixes the input rather than getting a quietly skewed
+    // file.
+    last_error = "Cannot write merged COPC: input catalog has no valid 3D "
+      "bounding box. This typically means the input is a legacy VPC whose "
+      "proj:bbox is 4-element (no z). Either regenerate the VPC with a "
+      "6-element properties.proj:bbox, or write per-tile COPC by using a "
+      "'*' placeholder in the output filename.";
+    return false;
+  }
+  if (catalog_bbox_valid && merged_copc)
   {
     h.min_x = catalog_xmin;
     h.min_y = catalog_ymin;

--- a/src/LASRstages/writelas.cpp
+++ b/src/LASRstages/writelas.cpp
@@ -29,13 +29,18 @@ LASRlaswriter::LASRlaswriter()
   copc_bbox_xmax = copc_bbox_ymax = copc_bbox_zmax = 0.0;
   catalog_xmin = catalog_ymin = catalog_zmin = 0.0;
   catalog_xmax = catalog_ymax = catalog_zmax = 0.0;
+  catalog_total_points = 0;
   catalog_bbox_valid = false;
 }
 
 bool LASRlaswriter::process(FileCollection*& ctg)
 {
-  // Capture the union bbox over all input files. Used by set_header() to
-  // size the COPC output's octree correctly when merging multiple inputs.
+  // Capture the union bbox and total point count over all input files.
+  // Used by set_header() to (a) size the COPC output's octree to the
+  // union bbox, and (b) pick a non-trivial auto max_depth — the per-tile
+  // header count alone is file-1's only and too small for multi-file
+  // merges (compute_max_depth divides by max_points_per_octant and would
+  // otherwise pick a too-shallow depth).
   if (ctg)
   {
     catalog_xmin = ctg->get_xmin();
@@ -44,7 +49,10 @@ bool LASRlaswriter::process(FileCollection*& ctg)
     catalog_xmax = ctg->get_xmax();
     catalog_ymax = ctg->get_ymax();
     catalog_zmax = ctg->get_zmax();
-    catalog_bbox_valid = (catalog_xmin <= catalog_xmax) && (catalog_ymin <= catalog_ymax);
+    catalog_total_points = ctg->get_total_points();
+    catalog_bbox_valid = (catalog_xmin <= catalog_xmax) &&
+                         (catalog_ymin <= catalog_ymax) &&
+                         (catalog_zmin <= catalog_zmax);
   }
   return true;
 }
@@ -282,16 +290,17 @@ bool LASRlaswriter::set_header(Header*& header)
   h.version_minor = version_minor;
 
   // For multi-file merge into a single COPC output, override the per-tile
-  // bbox with the FileCollection's union bbox. The COPC writer uses this
-  // bbox to build the octree at open(); without the override, file 2's
-  // points (and beyond) would be clamped into file 1's octree edges,
-  // producing a structurally-correct but skewed COPC output.
+  // bbox AND the per-tile point count with the FileCollection's union and
+  // total. The COPC writer uses these at open(): bbox sizes the octree,
+  // total point count drives the auto-max_depth heuristic. Without the
+  // count override, depth comes out from file 1's count alone and is
+  // far too shallow for the merged data set (single-chunk pseudo-COPC).
   //
   // Gate on (merged && copc-suffix output): per-file mode (`*` placeholder)
   // creates one output per input tile, and each tile's output should use
-  // its own bbox — applying the catalog union there would inflate every
-  // per-tile output to cover the whole input set. Non-COPC writes ignore
-  // bbox at open anyway, but skip the override for clarity.
+  // its own bbox/count — applying the catalog values there would inflate
+  // every per-tile output to cover the whole input set. Non-COPC writes
+  // ignore both fields at open anyway, but skip the override for clarity.
   if (catalog_bbox_valid && merged && path_has_copc_suffix(template_filename))
   {
     h.min_x = catalog_xmin;
@@ -300,6 +309,7 @@ bool LASRlaswriter::set_header(Header*& header)
     h.max_x = catalog_xmax;
     h.max_y = catalog_ymax;
     h.max_z = catalog_zmax;
+    h.number_of_point_records = catalog_total_points;
   }
 
   try

--- a/src/LASRstages/writelas.cpp
+++ b/src/LASRstages/writelas.cpp
@@ -11,6 +11,26 @@ LASRlaswriter::LASRlaswriter()
   copc_bbox_set = false;
   copc_bbox_xmin = copc_bbox_ymin = copc_bbox_zmin = 0.0;
   copc_bbox_xmax = copc_bbox_ymax = copc_bbox_zmax = 0.0;
+  catalog_xmin = catalog_ymin = catalog_zmin = 0.0;
+  catalog_xmax = catalog_ymax = catalog_zmax = 0.0;
+  catalog_bbox_valid = false;
+}
+
+bool LASRlaswriter::process(FileCollection*& ctg)
+{
+  // Capture the union bbox over all input files. Used by set_header() to
+  // size the COPC output's octree correctly when merging multiple inputs.
+  if (ctg)
+  {
+    catalog_xmin = ctg->get_xmin();
+    catalog_ymin = ctg->get_ymin();
+    catalog_zmin = ctg->get_zmin();
+    catalog_xmax = ctg->get_xmax();
+    catalog_ymax = ctg->get_ymax();
+    catalog_zmax = ctg->get_zmax();
+    catalog_bbox_valid = (catalog_xmin <= catalog_xmax) && (catalog_ymin <= catalog_ymax);
+  }
+  return true;
 }
 
 LASRlaswriter::~LASRlaswriter() noexcept
@@ -244,6 +264,21 @@ bool LASRlaswriter::set_header(Header*& header)
   h.signature = "LASF";
   h.point_data_format = point_format;
   h.version_minor = version_minor;
+
+  // For multi-file merge into a single output, override the per-tile bbox
+  // with the FileCollection's union bbox. The COPC writer uses this bbox
+  // to build the octree at open(); without the override, file 2's points
+  // (and beyond) would be clamped into file 1's octree edges, producing
+  // a structurally-correct but skewed COPC output.
+  if (catalog_bbox_valid)
+  {
+    h.min_x = catalog_xmin;
+    h.min_y = catalog_ymin;
+    h.min_z = catalog_zmin;
+    h.max_x = catalog_xmax;
+    h.max_y = catalog_ymax;
+    h.max_z = catalog_zmax;
+  }
 
   try
   {

--- a/src/LASRstages/writelas.cpp
+++ b/src/LASRstages/writelas.cpp
@@ -302,7 +302,7 @@ bool LASRlaswriter::set_header(Header*& header)
   // every per-tile output to cover the whole input set. Non-COPC writes
   // ignore both fields at open anyway, but skip the override for clarity.
   const bool merged_copc = merged && path_has_copc_suffix(template_filename);
-  if (merged_copc && !catalog_bbox_valid)
+  if (merged_copc && experimental_writer && !catalog_bbox_valid)
   {
     // Catalog bbox is invalid (typically: legacy 4D-only VPC where the
     // reader couldn't recover z bounds; or no FileCollection seen). With
@@ -311,7 +311,9 @@ bool LASRlaswriter::set_header(Header*& header)
     // and auto-depth from a single tile, which produces a structurally
     // bad output (clamping at close, too-shallow depth). Refuse loudly
     // so the user fixes the input rather than getting a quietly skewed
-    // file.
+    // file. Only the new writer needs this guard: LASlib's
+    // LASwriterCOPC inventories at close and doesn't depend on accurate
+    // open-time bbox/count.
     last_error = "Cannot write merged COPC: input catalog has no valid 3D "
       "bounding box. This typically means the input is a legacy VPC whose "
       "proj:bbox is 4-element (no z). Either regenerate the VPC with a "

--- a/src/LASRstages/writelas.cpp
+++ b/src/LASRstages/writelas.cpp
@@ -2,8 +2,24 @@
 
 #include "LASio.h"
 
+#include <algorithm>  // std::equal
+#include <cctype>
 #include <cmath>      // std::isfinite
 #include <exception>  // std::exception_ptr, std::current_exception
+
+namespace
+{
+  bool path_has_copc_suffix(const std::string& path)
+  {
+    static const std::string suffix = ".copc.laz";
+    if (path.size() < suffix.size()) return false;
+    return std::equal(suffix.rbegin(), suffix.rend(), path.rbegin(),
+                      [](char a, char b) {
+                        return std::tolower((unsigned char)a) ==
+                               std::tolower((unsigned char)b);
+                      });
+  }
+}
 
 LASRlaswriter::LASRlaswriter()
 {
@@ -265,12 +281,18 @@ bool LASRlaswriter::set_header(Header*& header)
   h.point_data_format = point_format;
   h.version_minor = version_minor;
 
-  // For multi-file merge into a single output, override the per-tile bbox
-  // with the FileCollection's union bbox. The COPC writer uses this bbox
-  // to build the octree at open(); without the override, file 2's points
-  // (and beyond) would be clamped into file 1's octree edges, producing
-  // a structurally-correct but skewed COPC output.
-  if (catalog_bbox_valid)
+  // For multi-file merge into a single COPC output, override the per-tile
+  // bbox with the FileCollection's union bbox. The COPC writer uses this
+  // bbox to build the octree at open(); without the override, file 2's
+  // points (and beyond) would be clamped into file 1's octree edges,
+  // producing a structurally-correct but skewed COPC output.
+  //
+  // Gate on (merged && copc-suffix output): per-file mode (`*` placeholder)
+  // creates one output per input tile, and each tile's output should use
+  // its own bbox — applying the catalog union there would inflate every
+  // per-tile output to cover the whole input set. Non-COPC writes ignore
+  // bbox at open anyway, but skip the override for clarity.
+  if (catalog_bbox_valid && merged && path_has_copc_suffix(template_filename))
   {
     h.min_x = catalog_xmin;
     h.min_y = catalog_ymin;

--- a/src/LASRstages/writelas.h
+++ b/src/LASRstages/writelas.h
@@ -14,6 +14,7 @@ public:
   bool set_header(Header*& header) override;
   bool set_input_file_name(const std::string& file) override;
   bool set_output_file(const std::string& file) override;
+  bool process(FileCollection*& ctg) override;
   bool process(Point*& p) override;
   bool process(PointCloud*& las) override;
   bool is_streamable() const override { return true; };
@@ -50,6 +51,18 @@ private:
   unsigned char version_minor;
   unsigned char point_format;
   std::vector<AttributeAccessor> core_accessors;
+
+  // Union bbox over the input FileCollection, captured in process(ctg)
+  // before any per-tile processing. Used to size the COPC octree
+  // when merging many input files into a single .copc.laz output.
+  // NaN if not yet captured (single-file path).
+  double catalog_xmin;
+  double catalog_ymin;
+  double catalog_zmin;
+  double catalog_xmax;
+  double catalog_ymax;
+  double catalog_zmax;
+  bool catalog_bbox_valid;
 
   LASio* lasio;
 };

--- a/src/LASRstages/writelas.h
+++ b/src/LASRstages/writelas.h
@@ -52,16 +52,18 @@ private:
   unsigned char point_format;
   std::vector<AttributeAccessor> core_accessors;
 
-  // Union bbox over the input FileCollection, captured in process(ctg)
-  // before any per-tile processing. Used to size the COPC octree
-  // when merging many input files into a single .copc.laz output.
-  // NaN if not yet captured (single-file path).
+  // Union bbox + total point count over the input FileCollection, captured
+  // in process(ctg) before any per-tile processing. Used to size the COPC
+  // octree (bbox) and pick a non-trivial auto max_depth (point count) when
+  // merging many input files into a single .copc.laz output.
+  // catalog_bbox_valid is false if no FileCollection was seen.
   double catalog_xmin;
   double catalog_ymin;
   double catalog_zmin;
   double catalog_xmax;
   double catalog_ymax;
   double catalog_zmax;
+  uint64_t catalog_total_points;
   bool catalog_bbox_valid;
 
   LASio* lasio;

--- a/tests/testthat/test-copc-write.R
+++ b/tests/testthat/test-copc-write.R
@@ -168,6 +168,47 @@ test_that("write_copc produces progressive LOD across depths",
   expect_equal(exec(reader() + summarise(), on = o)$npoints, total)
 })
 
+test_that("write_copc uses XY-balanced shallow LOD sampling by default",
+{
+  # Low-depth overviews should be selected in map space so display reads are
+  # not biased by vertical/scanline structure. Compare the default against the
+  # internal escape hatch that restores pure 3D voxel-cell routing.
+  f = system.file("extdata", "bcts", "bcts_1.laz", package = "lasR")
+  skip_if(f == "", "bcts_1.laz not available")
+
+  prev_xy_depth = Sys.getenv("LASR_COPC_XY_LOD_DEPTH", unset = NA)
+  prev_xy_mult  = Sys.getenv("LASR_COPC_XY_LOD_GRID_MULTIPLIER", unset = NA)
+  on.exit({
+    if (is.na(prev_xy_depth)) Sys.unsetenv("LASR_COPC_XY_LOD_DEPTH") else Sys.setenv(LASR_COPC_XY_LOD_DEPTH = prev_xy_depth)
+    if (is.na(prev_xy_mult))  Sys.unsetenv("LASR_COPC_XY_LOD_GRID_MULTIPLIER") else Sys.setenv(LASR_COPC_XY_LOD_GRID_MULTIPLIER = prev_xy_mult)
+  }, add = TRUE)
+
+  write_with_xy_depth = function(depth) {
+    Sys.unsetenv("LASR_COPC_XY_LOD_GRID_MULTIPLIER")
+    if (is.na(depth)) Sys.unsetenv("LASR_COPC_XY_LOD_DEPTH")
+    else Sys.setenv(LASR_COPC_XY_LOD_DEPTH = as.character(depth))
+
+    o = tempfile(fileext = ".copc.laz")
+    on.exit(unlink(o), add = TRUE)
+    exec(write_copc(o, density = "normal", experimental_writer = TRUE), on = f)
+    c(
+      d0 = exec(reader_las(depth = 0) + summarise(), on = o)$npoints,
+      d1 = exec(reader_las(depth = 1) + summarise(), on = o)$npoints,
+      d2 = exec(reader_las(depth = 2) + summarise(), on = o)$npoints,
+      total = exec(reader() + summarise(), on = o)$npoints
+    )
+  }
+
+  xy_default = write_with_xy_depth(NA)
+  xyz_only   = write_with_xy_depth(-1)
+  src_n      = exec(reader() + summarise(), on = f)$npoints
+
+  expect_equal(xy_default[["total"]], src_n)
+  expect_equal(xyz_only[["total"]], src_n)
+  expect_gt(xy_default[["d1"]], xyz_only[["d1"]] * 1.05)
+  expect_gt(xy_default[["d2"]], xyz_only[["d2"]] * 1.03)
+})
+
 test_that("write_copc honours a tiny LASR_COPC_RESIDENT_BUDGET (forces flush path)",
 {
   # bcts_1.laz holds enough points that a 1 MB resident budget will fire
@@ -223,11 +264,13 @@ test_that("write_copc protects shallow LODs from early resident-budget flushes",
   prev_ram      = Sys.getenv("LASR_COPC_RAM_BUDGET",      unset = NA)
   prev_wb       = Sys.getenv("LASR_COPC_SPILL_WRITE_BUDGET", unset = NA)
   prev_protect  = Sys.getenv("LASR_COPC_PROTECTED_LOD_DEPTH", unset = NA)
+  prev_xy_depth = Sys.getenv("LASR_COPC_XY_LOD_DEPTH", unset = NA)
   on.exit({
     if (is.na(prev_resident)) Sys.unsetenv("LASR_COPC_RESIDENT_BUDGET") else Sys.setenv(LASR_COPC_RESIDENT_BUDGET = prev_resident)
     if (is.na(prev_ram))      Sys.unsetenv("LASR_COPC_RAM_BUDGET")      else Sys.setenv(LASR_COPC_RAM_BUDGET = prev_ram)
     if (is.na(prev_wb))       Sys.unsetenv("LASR_COPC_SPILL_WRITE_BUDGET") else Sys.setenv(LASR_COPC_SPILL_WRITE_BUDGET = prev_wb)
     if (is.na(prev_protect))  Sys.unsetenv("LASR_COPC_PROTECTED_LOD_DEPTH") else Sys.setenv(LASR_COPC_PROTECTED_LOD_DEPTH = prev_protect)
+    if (is.na(prev_xy_depth)) Sys.unsetenv("LASR_COPC_XY_LOD_DEPTH") else Sys.setenv(LASR_COPC_XY_LOD_DEPTH = prev_xy_depth)
   }, add = TRUE)
 
   write_with_protection = function(depth) {
@@ -235,7 +278,8 @@ test_that("write_copc protects shallow LODs from early resident-budget flushes",
       LASR_COPC_RESIDENT_BUDGET = as.character(1024L * 1024L),
       LASR_COPC_RAM_BUDGET = as.character(1024L * 1024L),
       LASR_COPC_SPILL_WRITE_BUDGET = as.character(2L * 1024L * 1024L),
-      LASR_COPC_PROTECTED_LOD_DEPTH = as.character(depth)
+      LASR_COPC_PROTECTED_LOD_DEPTH = as.character(depth),
+      LASR_COPC_XY_LOD_DEPTH = "-1"
     )
     o = tempfile(fileext = ".copc.laz")
     on.exit(unlink(o), add = TRUE)

--- a/tests/testthat/test-copc-write.R
+++ b/tests/testthat/test-copc-write.R
@@ -98,7 +98,7 @@ test_that("write_copc merges multiple input files into a single COPC",
   o = tempfile(fileext = ".copc.laz")
   on.exit(unlink(o), add = TRUE)
 
-  expect_error(exec(write_copc(o), on = c(f1, f2)), NA)
+  expect_error(exec(write_copc(o, experimental_writer = TRUE), on = c(f1, f2)), NA)
 
   n1 = exec(reader() + summarise(), on = f1)$npoints
   n2 = exec(reader() + summarise(), on = f2)$npoints

--- a/tests/testthat/test-copc-write.R
+++ b/tests/testthat/test-copc-write.R
@@ -89,6 +89,36 @@ test_that("write_copc round-trips a PDRF 6 input via the fast path",
   expect_equal(dst$npoints, src$npoints)
 })
 
+test_that("write_copc merges multiple input files into a single COPC",
+{
+  f1 = system.file("extdata", "bcts", "bcts_1.laz", package = "lasR")
+  f2 = system.file("extdata", "bcts", "bcts_2.laz", package = "lasR")
+  skip_if(f1 == "" || f2 == "", "bcts tiles not available")
+
+  o = tempfile(fileext = ".copc.laz")
+  on.exit(unlink(o), add = TRUE)
+
+  expect_error(exec(write_copc(o), on = c(f1, f2)), NA)
+
+  n1 = exec(reader() + summarise(), on = f1)$npoints
+  n2 = exec(reader() + summarise(), on = f2)$npoints
+  nout = exec(reader() + summarise(), on = o)$npoints
+  expect_equal(nout, n1 + n2)
+
+  # Read the COPC info VLR (at offset 375 + 54 in LAS 1.4 with COPC info as
+  # the first VLR) and assert the octree was sized to the UNION of the two
+  # input files' bboxes — not just file 1's. Without the union-bbox fix,
+  # center_y would be ~629279 (file 1's center) and halfsize ~121.5; with
+  # the fix, center_y ~629429 (union center) and halfsize ~271.4.
+  con = file(o, open = "rb")
+  on.exit(close(con), add = TRUE)
+  seek(con, 375 + 54)
+  center_xyz = readBin(con, "double", n = 3)
+  halfsize   = readBin(con, "double", n = 1)
+  expect_gt(center_xyz[2], 629350)  # union center, not file-1 center
+  expect_gt(halfsize, 200)           # union halfsize, not file-1 halfsize
+})
+
 test_that("write_copc output is readable by lasR EPT-style reader with depth filter",
 {
   f = system.file("extdata", "Megaplot.las", package = "lasR")

--- a/tests/testthat/test-copc-write.R
+++ b/tests/testthat/test-copc-write.R
@@ -210,6 +210,55 @@ test_that("write_copc honours a tiny LASR_COPC_RESIDENT_BUDGET (forces flush pat
   expect_equal(unname(tools::md5sum(o1)), unname(tools::md5sum(o2)))
 })
 
+test_that("write_copc protects shallow LODs from early resident-budget flushes",
+{
+  # Under a tight resident budget, unprotected shallow octants can be frozen
+  # before the whole input stream has had a chance to compete for their voxels.
+  # Protecting depths 0..2 should keep depth-1/depth-2 overview counts much
+  # richer while preserving the full point count.
+  f = system.file("extdata", "bcts", "bcts_1.laz", package = "lasR")
+  skip_if(f == "", "bcts_1.laz not available")
+
+  prev_resident = Sys.getenv("LASR_COPC_RESIDENT_BUDGET", unset = NA)
+  prev_ram      = Sys.getenv("LASR_COPC_RAM_BUDGET",      unset = NA)
+  prev_wb       = Sys.getenv("LASR_COPC_SPILL_WRITE_BUDGET", unset = NA)
+  prev_protect  = Sys.getenv("LASR_COPC_PROTECTED_LOD_DEPTH", unset = NA)
+  on.exit({
+    if (is.na(prev_resident)) Sys.unsetenv("LASR_COPC_RESIDENT_BUDGET") else Sys.setenv(LASR_COPC_RESIDENT_BUDGET = prev_resident)
+    if (is.na(prev_ram))      Sys.unsetenv("LASR_COPC_RAM_BUDGET")      else Sys.setenv(LASR_COPC_RAM_BUDGET = prev_ram)
+    if (is.na(prev_wb))       Sys.unsetenv("LASR_COPC_SPILL_WRITE_BUDGET") else Sys.setenv(LASR_COPC_SPILL_WRITE_BUDGET = prev_wb)
+    if (is.na(prev_protect))  Sys.unsetenv("LASR_COPC_PROTECTED_LOD_DEPTH") else Sys.setenv(LASR_COPC_PROTECTED_LOD_DEPTH = prev_protect)
+  }, add = TRUE)
+
+  write_with_protection = function(depth) {
+    Sys.setenv(
+      LASR_COPC_RESIDENT_BUDGET = as.character(1024L * 1024L),
+      LASR_COPC_RAM_BUDGET = as.character(1024L * 1024L),
+      LASR_COPC_SPILL_WRITE_BUDGET = as.character(2L * 1024L * 1024L),
+      LASR_COPC_PROTECTED_LOD_DEPTH = as.character(depth)
+    )
+    o = tempfile(fileext = ".copc.laz")
+    on.exit(unlink(o), add = TRUE)
+    exec(write_copc(o, density = "normal", experimental_writer = TRUE), on = f)
+    c(
+      d0 = exec(reader_las(depth = 0) + summarise(), on = o)$npoints,
+      d1 = exec(reader_las(depth = 1) + summarise(), on = o)$npoints,
+      d2 = exec(reader_las(depth = 2) + summarise(), on = o)$npoints,
+      total = exec(reader() + summarise(), on = o)$npoints
+    )
+  }
+
+  unprotected = write_with_protection(0)
+  protected   = write_with_protection(2)
+  src_n       = exec(reader() + summarise(), on = f)$npoints
+
+  expect_equal(unprotected[["total"]], src_n)
+  expect_equal(protected[["total"]], src_n)
+  expect_equal(protected[["d0"]], unprotected[["d0"]])
+  expect_gt(protected[["d1"]], unprotected[["d1"]] * 2)
+  expect_gt(protected[["d2"]], unprotected[["d2"]] * 4)
+})
+
 test_that("write_copc honours LASR_COPC_MEMORY_BUDGET (single global knob)",
 {
   # Setting only LASR_COPC_MEMORY_BUDGET should split internally into the


### PR DESCRIPTION
This pull request improves the robustness and correctness of merged COPC (Cloud Optimized Point Cloud) file writing by ensuring accurate 3D bounding boxes and point counts are used throughout the pipeline. It enforces strict validation of input metadata, updates the handling of 3D bounds in both reading and writing, and adds safeguards to prevent malformed outputs when merging multiple files. A new test verifies the correctness of the merged COPC output.

**Improvements to 3D bounding box and point count handling:**

* Enforces that all features in a VPC (Virtual Point Cloud) file must have a consistent 3D bounding box (`proj:bbox` with 6 elements); mixed 2D/3D bboxes now cause a clear error, preventing silent creation of malformed merged outputs. [[1]](diffhunk://#diff-3b541fbefa02dd4a4a6b81e2c06eb47ef0eb3582cac84e65cd44ebb7ed754a19R202-R209) [[2]](diffhunk://#diff-3b541fbefa02dd4a4a6b81e2c06eb47ef0eb3582cac84e65cd44ebb7ed754a19L256-R284) [[3]](diffhunk://#diff-3b541fbefa02dd4a4a6b81e2c06eb47ef0eb3582cac84e65cd44ebb7ed754a19R306-R310) [[4]](diffhunk://#diff-3b541fbefa02dd4a4a6b81e2c06eb47ef0eb3582cac84e65cd44ebb7ed754a19R326-R344)
* Updates the reading of point counts in `read_vpc` to use 64-bit integers, preventing silent truncation for large datasets.
* Ensures the union 3D bounding box and total point count are properly tracked and exposed in `FileCollection`, and used when merging files into a single COPC output. [[1]](diffhunk://#diff-3b541fbefa02dd4a4a6b81e2c06eb47ef0eb3582cac84e65cd44ebb7ed754a19R723-R724) [[2]](diffhunk://#diff-3b541fbefa02dd4a4a6b81e2c06eb47ef0eb3582cac84e65cd44ebb7ed754a19R1007-R1010) [[3]](diffhunk://#diff-3b541fbefa02dd4a4a6b81e2c06eb47ef0eb3582cac84e65cd44ebb7ed754a19R1090-R1096) [[4]](diffhunk://#diff-74fd1cc9f9e2a29d6e48d5f61c99f92a6442ba943f2049981cd060bea995a030R52-R60) [[5]](diffhunk://#diff-74fd1cc9f9e2a29d6e48d5f61c99f92a6442ba943f2049981cd060bea995a030R89-R92)

**COPC writing and validation enhancements:**

* In `LASRlaswriter`, captures the union bounding box and total point count from the input collection and uses them to size the COPC octree and compute the correct auto max_depth for merged outputs; refuses to write merged COPC files if the input lacks a valid 3D bounding box. [[1]](diffhunk://#diff-04d99fb886db0604f627cc2ec09512a02747963a577cbb4b7b56aa1c38829d30R5-R53) [[2]](diffhunk://#diff-04d99fb886db0604f627cc2ec09512a02747963a577cbb4b7b56aa1c38829d30R246-R286) [[3]](diffhunk://#diff-2edbecc09a34beeedbaf62eed581b4bdb4f240cc936163371ba209e79404a25dR17) [[4]](diffhunk://#diff-2edbecc09a34beeedbaf62eed581b4bdb4f240cc936163371ba209e79404a25dR39-R52)
* Updates the VPC writing logic to always emit 6-element 3D `proj:bbox` arrays, aligning with the stricter requirements for merged COPC outputs. [[1]](diffhunk://#diff-3b541fbefa02dd4a4a6b81e2c06eb47ef0eb3582cac84e65cd44ebb7ed754a19L451-R507) [[2]](diffhunk://#diff-3b541fbefa02dd4a4a6b81e2c06eb47ef0eb3582cac84e65cd44ebb7ed754a19L464-R516) [[3]](diffhunk://#diff-3b541fbefa02dd4a4a6b81e2c06eb47ef0eb3582cac84e65cd44ebb7ed754a19L492-R556)

**Testing improvements:**

* Adds a new test to verify that merging multiple input files into a single COPC output produces the correct union bounding box and point count, ensuring the octree is sized to the union of all input files.