### PR TITLE
Update Windows CI to install Python packages via MSYS2

### DIFF
--- a/.github/workflows/pylasr.yaml
+++ b/.github/workflows/pylasr.yaml
@@ -122,15 +122,10 @@ jobs:
           mingw-w64-x86_64-tbb
           mingw-w64-x86_64-python
           mingw-w64-x86_64-python-pip
-
-    - name: Install Python packages
-      shell: msys2 {0}
-      run: |
-        # Check Python version and install packages
-        python --version
-        which python
-        python -m pip install --upgrade pip
-        python -m pip install setuptools wheel numpy pybind11
+          mingw-w64-x86_64-python-setuptools
+          mingw-w64-x86_64-python-wheel
+          mingw-w64-x86_64-python-numpy
+          mingw-w64-x86_64-python-pybind11
 
     - name: Configure pybind11 path
       shell: msys2 {0}

--- a/.github/workflows/pylasr.yaml
+++ b/.github/workflows/pylasr.yaml
@@ -125,7 +125,12 @@ jobs:
           mingw-w64-x86_64-python-setuptools
           mingw-w64-x86_64-python-wheel
           mingw-w64-x86_64-python-numpy
-          mingw-w64-x86_64-python-pybind11
+
+    - name: Install pybind11 (not packaged for MinGW)
+      shell: msys2 {0}
+      run: |
+        # MSYS2's Python is PEP 668 externally-managed; runner is ephemeral.
+        python -m pip install --break-system-packages pybind11
 
     - name: Configure pybind11 path
       shell: msys2 {0}


### PR DESCRIPTION
Refactor the Windows CI configuration to install Python packages directly through MSYS2, fixing the PEP668 error