### PR TITLE
test: compare CRS semantically, not by raw WKT bytes

### DIFF
--- a/tests/testthat/test-reader_dataframe.R
+++ b/tests/testthat/test-reader_dataframe.R
@@ -125,6 +125,13 @@ test_that("reader_dataframe propagates the CRS",
   rast = rasterize(2)
   u = exec(read+rast, on = las)
 
-  expect_equal(terra::crs(u), wkt)
+  # Compare CRS semantically rather than as raw WKT bytes. PROJ versions
+  # differ in WKT formatting (e.g., PROJ 9.x emits "298.257222101004" for
+  # the NAD83 inverse flattening where older PROJ emits "298.257222101";
+  # macOS-release runners sometimes pull a newer PROJ than the test was
+  # written against). sf::st_crs(...) == sf::st_crs(...) normalizes via
+  # PROJ and returns TRUE iff both inputs describe the same CRS — what
+  # this test actually wants to assert.
+  expect_true(sf::st_crs(terra::crs(u)) == sf::st_crs(wkt))
 })
 


### PR DESCRIPTION
## Summary

- Replaces a brittle WKT-string equality assertion in [test-reader_dataframe.R:128](tests/testthat/test-reader_dataframe.R#L128) with semantic CRS equality via `sf::st_crs(a) == sf::st_crs(b)`.
- Unblocks the macOS-latest (release) and test-coverage CI jobs, which fail today because their PROJ version emits `298.257222101004` for the NAD83 inverse flattening constant where the test's expected WKT has `298.257222101`. Both WKTs describe the same CRS (EPSG:26917) — only the byte representation differs.

## Why this matters

The test asserts that the CRS round-trips through `reader_dataframe`. PROJ-version drift between local dev environments and CI runners (or between R-CMD-check matrix entries) silently breaks the assertion without there being any actual code regression. The same flake also surfaces in the upstream `rlas` package on the same runner, confirming it's an environment issue, not a lasR bug.

`sf::st_crs(...) == sf::st_crs(...)` normalizes both inputs through PROJ and returns `TRUE` iff they describe the same CRS — exactly what this test wants to verify.

## Test plan

- [ ] CI green on macos-latest (release) where it was previously failing.
- [ ] CI green on test-coverage where it was previously failing.
- [ ] Other CI matrix entries (Ubuntu, Windows) remain green.