### PR TITLE
Fix callback arguments under coverage instrumentation

### DIFF
--- a/R/stages.R
+++ b/R/stages.R
@@ -182,7 +182,7 @@ aggregate_q = function(res, call, filter, ofile, env, ...)
 callback = function(fun, expose = "xyz", ..., drop_buffer = FALSE, no_las_update = FALSE)
 {
   args <- list(...)
-  fargs <- formals(fun)
+  fargs <- as.list(formals(fun))
   fargs <- fargs[-1]
   fargs[names(args)] <- args
 
@@ -1563,4 +1563,3 @@ LASATTRIBUTES <- c("X", "Y", "Z", "Intensity",
                    "ScannerChannel", "NIR",
                    "UserData", "gpstime", "PointSourceID",
                    "R", "G", "B")
-

--- a/tests/testthat/test-callback.R
+++ b/tests/testthat/test-callback.R
@@ -170,5 +170,14 @@ test_that("callback works with many args",
   expect_equal(ans, 15)
 })
 
-
+test_that("callback works with default args",
+{
+  f = system.file("extdata", "Example.las", package="lasR")
+  fun = function(data, multiplier = 2) { return(mean(data$Z) * multiplier) }
+  read = reader_las()
+  call = callback(fun = fun, expose = "xyz")
+  pipeline = read + call
+  ans = exec(pipeline, on = f)
+  expect_equal(ans, 1951.8, tolerance = 0.01)
+})
 


### PR DESCRIPTION
## Summary

- Coerce callback() formals to a regular list before passing them to the C++ callback stage.
- Add a regression test for callback functions that rely on default arguments.

## Why

formals(fun) returns a pairlist. The C++ callback builder later indexes the stored argument object with VECTOR_ELT(), which expects a list. Normal tests mostly avoided this because many callbacks had no default arguments, but coverage instrumentation can expose the latent pairlist path.

## Verification

- pkgload::load_all(".") plus targeted test-callback.R and test-add_attribute.R files.
- covr::package_coverage(".", type = "none") with a minimal callback default-argument smoke test.