### PR TITLE
Fix callback default args #2 + CRS test update from main

### DIFF
--- a/R/pipeline_tools.R
+++ b/R/pipeline_tools.R
@@ -37,6 +37,19 @@ print.PipelinePtr <- function(x, ...)
     stop("Both operands must be of class PipelinePtr") # nocov
 
   ans = .APIOPERATIONS$merge_pipeline(e1, e2);
+
+  # Carry over SEXPs that callback/aggregate stages reference by raw address
+  # (func/args/call/env). The C++ pipeline stores their addresses in the JSON
+  # config, so the underlying R objects must outlive every '+' to avoid GC
+  # reusing the slot.
+  preserved <- c(attr(e1, "preserved"), attr(e2, "preserved"))
+  for (key in c("func", "args", "call", "env"))
+  {
+    v1 <- attr(e1, key); if (!is.null(v1)) preserved <- c(preserved, list(v1))
+    v2 <- attr(e2, key); if (!is.null(v2)) preserved <- c(preserved, list(v2))
+  }
+  if (length(preserved) > 0) attr(ans, "preserved") <- preserved
+
   return(ans)
 }
 

--- a/R/stages.R
+++ b/R/stages.R
@@ -182,7 +182,7 @@ aggregate_q = function(res, call, filter, ofile, env, ...)
 callback = function(fun, expose = "xyz", ..., drop_buffer = FALSE, no_las_update = FALSE)
 {
   args <- list(...)
-  fargs <- formals(fun)
+  fargs <- as.list(formals(fun))
   fargs <- fargs[-1]
   fargs[names(args)] <- args
 
@@ -1563,4 +1563,3 @@ LASATTRIBUTES <- c("X", "Y", "Z", "Intensity",
                    "ScannerChannel", "NIR",
                    "UserData", "gpstime", "PointSourceID",
                    "R", "G", "B")
-

--- a/tests/testthat/test-callback.R
+++ b/tests/testthat/test-callback.R
@@ -170,5 +170,14 @@ test_that("callback works with many args",
   expect_equal(ans, 15)
 })
 
-
+test_that("callback works with default args",
+{
+  f = system.file("extdata", "Example.las", package="lasR")
+  fun = function(data, multiplier = 2) { return(mean(data$Z) * multiplier) }
+  read = reader_las()
+  call = callback(fun = fun, expose = "xyz")
+  pipeline = read + call
+  ans = exec(pipeline, on = f)
+  expect_equal(ans, 1951.8, tolerance = 0.01)
+})
 

--- a/tests/testthat/test-reader_dataframe.R
+++ b/tests/testthat/test-reader_dataframe.R
@@ -125,6 +125,13 @@ test_that("reader_dataframe propagates the CRS",
   rast = rasterize(2)
   u = exec(read+rast, on = las)
 
-  expect_equal(terra::crs(u), wkt)
+  # Compare CRS semantically rather than as raw WKT bytes. PROJ versions
+  # differ in WKT formatting (e.g., PROJ 9.x emits "298.257222101004" for
+  # the NAD83 inverse flattening where older PROJ emits "298.257222101";
+  # macOS-release runners sometimes pull a newer PROJ than the test was
+  # written against). sf::st_crs(...) == sf::st_crs(...) normalizes via
+  # PROJ and returns TRUE iff both inputs describe the same CRS — what
+  # this test actually wants to assert.
+  expect_true(sf::st_crs(terra::crs(u)) == sf::st_crs(wkt))
 })
 


### PR DESCRIPTION
This pull request introduces improvements to pipeline merging, callback handling, and testing robustness, mainly focusing on better management of R object lifetimes, argument handling, and test reliability.

### Pipeline merging and memory management
* Ensures that R objects referenced by pipeline stages (such as `func`, `args`, `call`, and `env`) are preserved across pipeline merges to prevent garbage collection issues, by carrying over these objects in the `preserved` attribute during the merge operation in `PipelinePtr`.

### Callback and argument handling
* Changes the callback creation to use `as.list(formals(fun))` for argument extraction, improving compatibility and correctness when handling function arguments.

### Testing improvements
* Adds a new test to verify that the callback mechanism works correctly with functions that have default arguments.


### Minor cleanup
* Removes a trailing blank line in the LAS attributes definition for code cleanliness.