### PR TITLE
Read WKT projection record from Extended VLRs

### DIFF
--- a/src/LASRreaders/LASio.cpp
+++ b/src/LASRreaders/LASio.cpp
@@ -291,6 +291,25 @@ void LASio::populate_header(Header* header, bool read_first_point)
     }
   }
 
+  // The LAS 1.4 spec also allows the WKT projection record (user_id "LASF_Projection",
+  // record_id 2112) to live in an Extended VLR. LASlib's vlr_geo_ogc_wkt flag and the
+  // vlrs[] array only cover regular VLRs, so we have to iterate evlrs[] separately.
+  if (!header->crs.is_valid())
+  {
+    for (unsigned int j = 0; j < lasreader->header.number_of_extended_variable_length_records; j++)
+    {
+      const LASevlr& evlr = lasreader->header.evlrs[j];
+      if (strncmp(evlr.user_id, "LASF_Projection", 16) == 0 && evlr.record_id == 2112 && evlr.data != nullptr)
+      {
+        char* data = (char*)evlr.data;
+        size_t len = strnlen(data, (size_t)evlr.record_length_after_header);
+        std::string wkt(data, len);
+        header->set_crs(wkt);
+        break;
+      }
+    }
+  }
+
   header->spatial_index = (lasreader->get_index() != nullptr) || (lasreader->get_copcindex() != nullptr);
 
 


### PR DESCRIPTION
## Summary

LAS 1.4 lets the WKT projection record (user_id `LASF_Projection`, record_id `2112`) live in either a regular VLR **or** an Extended VLR. The reader at `src/LASRreaders/LASio.cpp` only iterated `header.vlrs[]`, so files where the producer chose an EVLR fell through silently — `info()` printed `Coord. ref. : (null)` and every downstream raster/vector/LAS output was written CRS-less.

EVLR placement is common for COPC and other streaming writers (the EVLR sits at the end of the file, so the writer doesn't have to commit to projection metadata before writing points), and is required when a WKT2 string nears or exceeds the 64 KB regular-VLR cap.

## Fix

Add a second loop over `header.evlrs[]`, mirroring the existing regular-VLR block, gated on `!header->crs.is_valid()` so a regular VLR (read first) is never overwritten. Strict on `user_id == "LASF_Projection"` to avoid accidental matches against unrelated EVLR record IDs.

```cpp
if (!header->crs.is_valid())
{
  for (unsigned int j = 0; j < lasreader->header.number_of_extended_variable_length_records; j++)
  {
    const LASevlr& evlr = lasreader->header.evlrs[j];
    if (strncmp(evlr.user_id, "LASF_Projection", 16) == 0 &&
        evlr.record_id == 2112 && evlr.data != nullptr)
    {
      char* data = (char*)evlr.data;
      size_t len = strnlen(data, (size_t)evlr.record_length_after_header);
      header->set_crs(std::string(data, len));
      break;
    }
  }
}
```

## Reproduction

A USGS LPC delivery (CA NorthCoastRanges B23, generated by NV5 Geospatial Lidar Suite) ships its compound CRS *NAD83(2011) / UTM zone 10N + NAVD88 height - Geoid18 (m)* in a single 903-byte EVLR. Both `lasinfo` and `pdal info` parse it cleanly; `lasR::info()` printed `(null)` before this patch.

```
extended variable length header record 1 of 1:
  user ID:     'LASF_Projection'
  record ID:   2112
  description: 'WKT Projection'
```

## Verification

| input | before | after |
|---|---|---|
| LAZ with EVLR-stored WKT (USGS LPC) | `Coord. ref.: (null)` | `Coord. ref.: NAD83(2011) / UTM zone 10N + NAVD88 height - Geoid18 (m)` |
| `extdata/Topography.las` (regular VLR WKT) | reads CRS | reads CRS (unchanged) |
| `extdata/nocrs.las` | `Coord. ref.: (null)` | `Coord. ref.: (null)` (unchanged) |

`testthat` results identical between pristine `devel` and this branch on the three suites with non-zero failure counts (`test-filter.R`, `test-print.R`, `test-pipelines.R`) — all pre-existing on `devel`, none related to projection handling.

## Test plan

- [x] LAS 1.4 file with EVLR-stored WKT now reports CRS via `info()`
- [x] LAS file with regular VLR WKT still reports CRS (no double-write, no overwrite)
- [x] LAS file with no projection record still reports `(null)`
- [x] Full `tests/testthat` run shows no new failures vs `devel`