### PR TITLE
Implement Python callback functionality in pylasr

### DIFF
--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -224,6 +224,7 @@ pybind11_add_module(pylasr
   ${LASR_SOURCE_DIR}/src/LASRstages/addattribute.cpp
   ${LASR_SOURCE_DIR}/src/LASRstages/boundaries.cpp
   ${LASR_SOURCE_DIR}/src/LASRstages/breakif.cpp
+  ${LASR_SOURCE_DIR}/src/LASRstages/callback.cpp
   ${LASR_SOURCE_DIR}/src/LASRstages/csf.cpp
   ${LASR_SOURCE_DIR}/src/LASRstages/edit.cpp
   ${LASR_SOURCE_DIR}/src/LASRstages/focal.cpp

--- a/python/bindings.cpp
+++ b/python/bindings.cpp
@@ -7,6 +7,7 @@
 #include <filesystem>
 
 #include "LASRapi/api.h"
+#include "callback.h"
 
 namespace py = pybind11;
 
@@ -440,6 +441,45 @@ PYBIND11_MODULE(pylasr, m) {
     "Find local maxima in raster",
     py::arg("connect_uid"), py::arg("ws"), py::arg("min_height") = 2.0,
     py::arg("filter") = std::vector<std::string>{""}, py::arg("ofile") = "");
+
+    m.def("callback", [](py::object fun, const std::string& expose, py::object args, bool drop_buffer, bool no_las_update) {
+        if (!py::hasattr(fun, "__call__"))
+            throw py::type_error("fun must be callable");
+
+        py::tuple callback_args;
+        if (args.is_none())
+        {
+            callback_args = py::tuple();
+        }
+        else if (py::isinstance<py::tuple>(args))
+        {
+            callback_args = args.cast<py::tuple>();
+        }
+        else if (py::isinstance<py::list>(args))
+        {
+            py::list list_args = args.cast<py::list>();
+            callback_args = py::tuple(list_args.size());
+            for (py::ssize_t i = 0; i < list_args.size(); ++i)
+                callback_args[i] = list_args[i];
+        }
+        else
+        {
+            throw py::type_error("args must be None, a tuple, or a list");
+        }
+
+        std::string id = lasr_python_callback::register_callback(fun, callback_args);
+
+        api::Stage s("callback");
+        s.set("fun", id);
+        s.set("args", "");
+        s.set("expose", expose);
+        s.set("drop_buffer", drop_buffer);
+        s.set("no_las_update", no_las_update);
+        return api::Pipeline(s);
+    },
+    "Run a Python callback on point-cloud chunks. The callable receives a dict of NumPy arrays and may return a dict to update point attributes.",
+    py::arg("fun"), py::arg("expose") = "xyz", py::arg("args") = py::none(),
+    py::arg("drop_buffer") = false, py::arg("no_las_update") = false);
 
     // Triangulation and hulls
     m.def("triangulate", &api::triangulate,

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "pylasr"
-version = "0.17.4"
+version = "0.21.0"
 description = "Python bindings for LASR library - Fast Airborne LiDAR Data Processing"
 readme = "README.md"
 requires-python = ">=3.9"

--- a/python/tests/test_functions.py
+++ b/python/tests/test_functions.py
@@ -210,6 +210,14 @@ class TestGeometricAnalysis(unittest.TestCase):
         )
         self.assertIsInstance(pipeline, pylasr.Pipeline)
 
+    def test_callback(self):
+        """Test callback pipeline creation"""
+        def passthrough(data):
+            return data
+
+        pipeline = pylasr.callback(passthrough, expose="xyz")
+        self.assertIsInstance(pipeline, pylasr.Pipeline)
+
     def test_triangulate(self):
         """Test triangulate pipeline creation"""
         pipeline = pylasr.triangulate(

--- a/src/LASRcore/parser.cpp
+++ b/src/LASRcore/parser.cpp
@@ -61,6 +61,8 @@ static SEXP get_element(SEXP list, const char *str)
   if (Rf_isNull(elmt)) throw std::string("element '") + str +  "' not found"; // # nocov
   return elmt;
 }
+#elif defined(USING_PYTHON)
+#include "callback.h"
 #endif
 
 template <typename T>
@@ -130,6 +132,8 @@ bool Engine::parse(const nlohmann::json& json, bool progress)
     ,{"aggregate",           create_instance<LASRaggregate>},
     {"callback",             create_instance<LASRcallback>},
     {"xptr",                 create_instance<LASRxptr>}
+    #elif defined(USING_PYTHON)
+    ,{"callback",            create_instance<LASRcallback>}
     #endif
   };
 

--- a/src/LASRstages/callback.cpp
+++ b/src/LASRstages/callback.cpp
@@ -451,3 +451,333 @@ SEXP LASRcallback::to_R()
 }
 
 #endif
+
+#ifdef USING_PYTHON
+
+#include "callback.h"
+
+#include <mutex>
+#include <sstream>
+#include <unordered_map>
+#include <unordered_set>
+
+#include <pybind11/numpy.h>
+#include <pybind11/stl.h>
+
+namespace py = pybind11;
+
+namespace
+{
+  struct PyCallback
+  {
+    py::object callable;
+    py::tuple args;
+  };
+
+  std::mutex& callback_registry_mutex()
+  {
+    static auto* mutex = new std::mutex();
+    return *mutex;
+  }
+
+  std::unordered_map<std::string, PyCallback>& callback_registry()
+  {
+    static auto* registry = new std::unordered_map<std::string, PyCallback>();
+    return *registry;
+  }
+
+  unsigned long long& callback_registry_counter()
+  {
+    static auto* counter = new unsigned long long(0);
+    return *counter;
+  }
+
+  PyCallback get_python_callback(const std::string& id)
+  {
+    std::lock_guard<std::mutex> lock(callback_registry_mutex());
+    auto& registry = callback_registry();
+    auto it = registry.find(id);
+    if (it == registry.end())
+      throw std::runtime_error("unknown Python callback id: " + id);
+
+    return it->second;
+  }
+
+  std::string normalize_select(std::string select)
+  {
+    std::string all = "xyzitrndecskwoaupRGBNCbE";
+    size_t pos = select.find('*');
+    if (pos != std::string::npos) select = all;
+
+    std::string parsed;
+    std::unordered_set<char> seen;
+    for (char c : select)
+    {
+      if (seen.insert(c).second)
+        parsed += c;
+    }
+
+    return parsed;
+  }
+
+  struct CallbackColumn
+  {
+    std::string name;
+    AttributeAccessor accessor;
+    Attribute attribute = Attribute("", AttributeType::NOTYPE);
+    bool is_buffer = false;
+    std::vector<double> values;
+  };
+
+  void add_column(
+    PointCloud* las,
+    const std::string& name,
+    std::vector<CallbackColumn>& columns,
+    bool is_buffer = false)
+  {
+    CallbackColumn column;
+    column.name = name;
+    column.is_buffer = is_buffer;
+    column.accessor = AttributeAccessor(name);
+
+    if (is_buffer)
+    {
+      column.attribute = Attribute(name, AttributeType::UINT8);
+    }
+    else
+    {
+      int index = las->header->schema.get_attribute_index(name);
+      if (index < 0) return;
+      column.name = las->header->schema.attributes[index].name;
+      column.attribute = las->header->schema.attributes[index];
+    }
+
+    column.values.reserve(las->npoints);
+    columns.push_back(column);
+  }
+
+  py::array_t<double> to_numpy_array(const std::vector<double>& values)
+  {
+    py::array_t<double> array(values.size());
+    auto out = array.mutable_unchecked<1>();
+    for (py::ssize_t i = 0; i < static_cast<py::ssize_t>(values.size()); ++i)
+      out(i) = values[i];
+    return array;
+  }
+
+  py::tuple make_python_call_args(const py::dict& data, const py::tuple& args)
+  {
+    py::tuple call_args(args.size() + 1);
+    call_args[0] = data;
+    for (py::ssize_t i = 0; i < args.size(); ++i)
+      call_args[i + 1] = args[i];
+    return call_args;
+  }
+
+  std::string py_object_to_string(const py::handle& object)
+  {
+    return py::str(object).cast<std::string>();
+  }
+}
+
+namespace lasr_python_callback
+{
+  std::string register_callback(py::object callable, py::tuple args)
+  {
+    std::lock_guard<std::mutex> lock(callback_registry_mutex());
+    std::string id = "py_callback_" + std::to_string(++callback_registry_counter());
+    callback_registry().emplace(id, PyCallback{std::move(callable), std::move(args)});
+    return id;
+  }
+}
+
+bool LASRcallback::set_parameters(const nlohmann::json& stage)
+{
+  select = normalize_select(stage.value("expose", "xyz"));
+  modify = !stage.value("no_las_update", false);
+  drop_buffer = stage.value("drop_buffer", false);
+  callback_id = stage.at("fun").get<std::string>();
+  return true;
+}
+
+bool LASRcallback::process(PointCloud*& las)
+{
+  if (!las)
+  {
+    last_error = "Uninitialized pointer to LAS object";
+    return false;
+  }
+
+  py::gil_scoped_acquire gil;
+
+  try
+  {
+    PyCallback callback = get_python_callback(callback_id);
+
+    std::vector<CallbackColumn> columns;
+    for (char c : select)
+    {
+      if (c >= '0' && c <= '9')
+      {
+        int requested_extra = c - '0';
+        int current_extra = 0;
+        for (const auto& attribute : las->header->schema.attributes)
+        {
+          if (lascoreattributes.count(attribute.name) == 0)
+          {
+            if (current_extra == requested_extra)
+            {
+              add_column(las, attribute.name, columns);
+              break;
+            }
+            current_extra++;
+          }
+        }
+      }
+      else if (c == 'E')
+      {
+        for (const auto& attribute : las->header->schema.attributes)
+        {
+          if (lascoreattributes.count(attribute.name) == 0)
+            add_column(las, attribute.name, columns);
+        }
+      }
+      else if (c == 'b')
+      {
+        add_column(las, "Buffer", columns, true);
+      }
+      else
+      {
+        add_column(las, map_attribute(std::string(1, c)), columns);
+      }
+    }
+
+    while (las->read_point())
+    {
+      bool buffer = las->point.get_buffered();
+      if (drop_buffer && buffer)
+        continue;
+
+      for (auto& column : columns)
+      {
+        double value = column.is_buffer ? static_cast<double>(buffer) : column.accessor(&las->point);
+        column.values.push_back(value);
+      }
+    }
+
+    py::dict data;
+    for (const auto& column : columns)
+      data[py::str(column.name)] = to_numpy_array(column.values);
+
+    py::tuple call_args = make_python_call_args(data, callback.args);
+    py::object result = py::reinterpret_steal<py::object>(PyObject_CallObject(callback.callable.ptr(), call_args.ptr()));
+    if (!result)
+      throw py::error_already_set();
+
+    if (!modify || result.is_none() || !py::isinstance<py::dict>(result))
+    {
+      las->update_header();
+      return true;
+    }
+
+    py::dict output = result.cast<py::dict>();
+    struct OutputColumn
+    {
+      std::string name;
+      AttributeAccessor accessor;
+      py::array_t<double, py::array::c_style | py::array::forcecast> values;
+      bool is_buffer = false;
+      bool is_withheld = false;
+    };
+
+    std::vector<OutputColumn> output_columns;
+    for (auto item : output)
+    {
+      std::string name = py_object_to_string(item.first);
+
+      if (name == "Buffer")
+      {
+        OutputColumn column;
+        column.name = name;
+        column.is_buffer = true;
+        column.values = py::array_t<double, py::array::c_style | py::array::forcecast>::ensure(item.second);
+        if (!column.values)
+          throw std::runtime_error("callback column '" + name + "' cannot be converted to a numeric array");
+        output_columns.push_back(column);
+      }
+      else if (name == "Withheld")
+      {
+        OutputColumn column;
+        column.name = name;
+        column.is_withheld = true;
+        column.values = py::array_t<double, py::array::c_style | py::array::forcecast>::ensure(item.second);
+        if (!column.values)
+          throw std::runtime_error("callback column '" + name + "' cannot be converted to a numeric array");
+        output_columns.push_back(column);
+      }
+      else
+      {
+        if (!las->header->schema.has_attribute(name))
+          throw std::runtime_error("non supported column '" + name + "'");
+
+        OutputColumn column;
+        column.name = name;
+        column.accessor = AttributeAccessor(name);
+        column.values = py::array_t<double, py::array::c_style | py::array::forcecast>::ensure(item.second);
+        if (!column.values)
+          throw std::runtime_error("callback column '" + name + "' cannot be converted to a numeric array");
+        output_columns.push_back(column);
+      }
+    }
+
+    py::ssize_t npoints = columns.empty() ? static_cast<py::ssize_t>(las->npoints) : static_cast<py::ssize_t>(columns[0].values.size());
+    for (const auto& column : output_columns)
+    {
+      if (column.values.ndim() != 1)
+        throw std::runtime_error("callback column '" + column.name + "' must be a one-dimensional array");
+      if (column.values.shape(0) != npoints)
+      {
+        std::ostringstream oss;
+        oss << "callback column '" << column.name << "' has length " << column.values.shape(0)
+            << " but expected " << npoints;
+        throw std::runtime_error(oss.str());
+      }
+    }
+
+    py::ssize_t i = 0;
+    while (las->read_point())
+    {
+      bool buffer = las->point.get_buffered();
+      if (drop_buffer && buffer)
+        continue;
+
+      for (auto& column : output_columns)
+      {
+        auto values = column.values.unchecked<1>();
+        double value = values(i);
+        if (column.is_buffer)
+          las->point.set_buffered(value != 0.0);
+        else if (column.is_withheld)
+          las->point.set_deleted(value != 0.0);
+        else
+          column.accessor(&las->point, value);
+      }
+      i++;
+    }
+
+    las->update_header();
+    return true;
+  }
+  catch (const py::error_already_set& e)
+  {
+    last_error = e.what();
+    return false;
+  }
+  catch (const std::exception& e)
+  {
+    last_error = e.what();
+    return false;
+  }
+}
+
+#endif

--- a/src/LASRstages/callback.h
+++ b/src/LASRstages/callback.h
@@ -34,6 +34,36 @@ private:
 };
 
 
+#elif defined(USING_PYTHON)
+
+#include "Stage.h"
+#include <string>
+#include <vector>
+#include <pybind11/pybind11.h>
+
+namespace lasr_python_callback
+{
+  std::string register_callback(pybind11::object callable, pybind11::tuple args);
+}
+
+class LASRcallback : public Stage
+{
+public:
+  LASRcallback() = default;
+  bool process(PointCloud*& las) override;
+  bool set_parameters(const nlohmann::json&) override;
+  std::string get_name() const override { return "callback";  }
+  bool is_parallelizable() const override { return false; }
+
+  LASRcallback* clone() const override { return new LASRcallback(*this); };
+
+private:
+  bool modify = true;
+  bool drop_buffer = false;
+  std::string select;
+  std::string callback_id;
+};
+
 #else
 #pragma message("LASRcallback skipped: cannot be compiled without R")
 #endif


### PR DESCRIPTION
Introduce a new callback feature that allows users to run Python functions on point-cloud chunks. This update includes necessary modifications to the bindings and adds a corresponding test to ensure functionality. The version number has been incremented to reflect these changes.