### PR TITLE
Enhance EPT reading with concurrency and other performance fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,4 @@ python/build
 *.a
 *.pyc
 CLAUDE.md
+.Rlib

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -29,6 +29,7 @@ Imports:
     Rcpp
 Suggests:
     httpuv,
+    jsonlite,
     knitr,
     rmarkdown,
     sf,

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,6 @@
 # lasR 0.21.0
 
+- Change: EPT auto-partition default target is 32 when `LASR_EPT_PARTITIONS` is unset (was `4 × concurrent_files` workers).
 - New: Support of Entwine Point Tile format
 - New: `classify_with_ivf` gains a parameter `filter` (#289)
 - Change: `drop_noise()` and `keep_noise()` now filter classes 7 and 18 instead of 18 only (#283)

--- a/src/LASRapi/ept_partition_gate.h
+++ b/src/LASRapi/ept_partition_gate.h
@@ -1,0 +1,24 @@
+#ifndef EPT_PARTITION_GATE_H
+#define EPT_PARTITION_GATE_H
+
+#include "FileCollection.h"
+
+namespace api_internal {
+
+// Predicate matching the gate in execute.cpp's auto-partition hook.
+// Returns true iff the engine should call FileCollection::partition_ept
+// before reading the chunk count.
+inline bool should_auto_partition_ept(PathType format,
+                                      bool is_parallelizable,
+                                      bool use_rcapi,
+                                      int ncpu_outer_loop)
+{
+  return is_parallelizable
+      && !use_rcapi
+      && ncpu_outer_loop > 1
+      && format == EPTFILE;
+}
+
+}  // namespace api_internal
+
+#endif

--- a/src/LASRapi/ept_partition_gate.h
+++ b/src/LASRapi/ept_partition_gate.h
@@ -5,6 +5,13 @@
 
 namespace api_internal {
 
+// Default EPT auto-partition target when LASR_EPT_PARTITIONS is unset.
+// Fixed at 32 (not 4×worker count): benchmarks on USGS 3DEP AOIs showed
+// 4×16→64 partitions creates too many small chunks (~100) and loses to
+// 8 workers at ~36 chunks; capping the target at 32 keeps chunk count stable
+// while concurrent_files(16) still wins on large AOIs.
+constexpr int default_ept_auto_partitions = 32;
+
 // Predicate matching the gate in execute.cpp's auto-partition hook.
 // Returns true iff the engine should call FileCollection::partition_ept
 // before reading the chunk count.

--- a/src/LASRapi/execute.cpp
+++ b/src/LASRapi/execute.cpp
@@ -158,7 +158,7 @@ ReturnType execute(const std::string& config_file)
             lascatalog->get_format(), is_parallelizable,
             use_rcapi, ncpu_outer_loop))
     {
-      int target = 4 * ncpu_outer_loop;
+      int target = api_internal::default_ept_auto_partitions;
       if (const char* env = getenv("LASR_EPT_PARTITIONS")) {
         int parsed = 0;
         try { parsed = std::stoi(env); } catch (...) { parsed = 0; }

--- a/src/LASRapi/execute.cpp
+++ b/src/LASRapi/execute.cpp
@@ -26,6 +26,7 @@
 
 #include "Engine.h"
 #include "FileCollection.h"
+#include "ept_partition_gate.h"
 
 #include "DrawflowParser.h"
 #include "nlohmann/json.hpp"
@@ -152,6 +153,24 @@ ReturnType execute(const std::string& config_file)
     bool is_parallelizable = pipeline.is_parallelizable();  // concurrent-files
 
     FileCollection* lascatalog = pipeline.get_catalog(); // the pipeline owns the catalog
+
+    if (api_internal::should_auto_partition_ept(
+            lascatalog->get_format(), is_parallelizable,
+            use_rcapi, ncpu_outer_loop))
+    {
+      int target = 4 * ncpu_outer_loop;
+      if (const char* env = getenv("LASR_EPT_PARTITIONS")) {
+        int parsed = 0;
+        try { parsed = std::stoi(env); } catch (...) { parsed = 0; }
+        if (parsed > 0 && parsed <= 4096) {
+          target = parsed;
+        } else {
+          warning("Ignoring invalid LASR_EPT_PARTITIONS=%s (must be 1..4096)\n", env);
+        }
+      }
+      if (!lascatalog->partition_ept(target))
+        throw std::runtime_error(last_error);
+    }
 
     int n = lascatalog->get_number_chunks();
 

--- a/src/LASRcore/Chunk.h
+++ b/src/LASRcore/Chunk.h
@@ -26,6 +26,9 @@ struct Chunk
     shape = ShapeType::UNKNOWN;
     buffer = 0;
     process = true;
+    strict_clip = false;
+    catalog_xmax = 0;
+    catalog_ymax = 0;
     name.clear();
     main_files.clear();
     neighbour_files.clear();
@@ -52,6 +55,9 @@ struct Chunk
   bool process;
   int id;
   ShapeType shape;
+  bool strict_clip;
+  double catalog_xmax;
+  double catalog_ymax;
   std::string name;
   std::vector<std::string> main_files;
   std::vector<std::string> neighbour_files;

--- a/src/LASRcore/Chunk.h
+++ b/src/LASRcore/Chunk.h
@@ -56,6 +56,12 @@ struct Chunk
   int id;
   ShapeType shape;
   bool strict_clip;
+  // Outer boundary at/beyond which strict_clip_decide treats
+  // px == xmax as CORE (the "rightmost cell carve-out"). For
+  // catalog-wide reads this equals the catalog's xmax/ymax; for
+  // AOI-derived sub-queries it's the clamped AOI bbox (so
+  // partitioned and un-partitioned AOI reads agree on
+  // boundary-coincident points).
   double catalog_xmax;
   double catalog_ymax;
   std::string name;

--- a/src/LASRcore/FileCollection.cpp
+++ b/src/LASRcore/FileCollection.cpp
@@ -925,7 +925,7 @@ bool FileCollection::partition_ept(int target_partitions)
   const double cxmax = ept_index->conf_bounds[3];
   const double cymax = ept_index->conf_bounds[4];
 
-  double aoi_area = 0.0;
+  bool any_partitionable = false;
   for (size_t i = 0; i < queries.size(); ++i) {
     Shape* q = queries[i];
     if (q->type() != ShapeType::RECTANGLE) continue;
@@ -935,36 +935,47 @@ bool FileCollection::partition_ept(int target_partitions)
     double bymax = std::min(q->ymax(), cymax);
     if (bxmin >= bxmax || bymin >= bymax) continue;  // disjoint → passthrough
     aoi_bboxes[i] = {bxmin, bymin, bxmax, bymax, true};
-    aoi_area += (bxmax - bxmin) * (bymax - bymin);
+    any_partitionable = true;
   }
 
-  if (aoi_area == 0.0) return true;  // nothing partitionable; leave queries unchanged
+  if (!any_partitionable) return true;  // nothing partitionable; leave queries unchanged
 
-  // Depth selection — float-safe with a hard cap, then int-cast.
+  // Depth selection.
   //
-  // For tiny AOIs (e.g., a sub-meter query against a 100 km cube), the
-  // ratio cube_area/aoi_area can be huge and `wanted` would overflow
-  // to inf. Converting inf to int is UB. Compare in double-space
-  // against `cap` first, only cast when finite and in range.
+  // The previous heuristic was an area ratio
+  // `d = ceil(0.5 * log2(target * cube_area / aoi_area))`. That was
+  // correct for square AOIs but undercounted long-thin AOIs: e.g. a
+  // 10 m × 1000 m AOI in a 1 km cube has 1 % area but its long axis
+  // already spans many cells at any reasonable depth, so the
+  // area-based formula could pick `d = 0` even when the AOI clearly
+  // wants several partitions.
+  //
+  // Instead, iterate `d` upward and count the integer cells covered
+  // by the (clamped) AOIs at that depth. Stop at the smallest `d`
+  // whose total cell count meets `target_partitions`, capped at
+  // min(16, max_tile_depth). Monotone in `d` so at most 17 steps.
   const double cube_size = ept_index->cube_bounds[3] - ept_index->cube_bounds[0];
-  const double cube_area = cube_size * cube_size;
   int max_tile_depth = 0;
   for (const auto& t : ept_index->tiles)
     if (t.key.d > max_tile_depth) max_tile_depth = t.key.d;
   const int cap = (max_tile_depth < 16 ? max_tile_depth : 16);
 
-  int d;
-  {
-    const double ratio = (double)target_partitions * cube_area / aoi_area;
-    if (!std::isfinite(ratio) || ratio <= 1.0) {
-      d = 0;
-    } else {
-      const double wanted = 0.5 * std::log2(ratio);
-      if (!std::isfinite(wanted) || wanted >= (double)cap) d = cap;
-      else if (wanted < 0.0) d = 0;
-      else { d = (int)std::ceil(wanted); if (d > cap) d = cap; }
+  auto cells_covered_at = [&](int dd) -> int64_t {
+    const double cell = cube_size / (double)(int64_t{1} << dd);
+    int64_t total = 0;
+    for (const auto& a : aoi_bboxes) {
+      if (!a.partitionable) continue;
+      int64_t cx_lo = (int64_t)std::floor((a.xmin - ept_index->cube_bounds[0]) / cell);
+      int64_t cx_hi = (int64_t)std::ceil ((a.xmax - ept_index->cube_bounds[0]) / cell);
+      int64_t cy_lo = (int64_t)std::floor((a.ymin - ept_index->cube_bounds[1]) / cell);
+      int64_t cy_hi = (int64_t)std::ceil ((a.ymax - ept_index->cube_bounds[1]) / cell);
+      total += (cx_hi - cx_lo) * (cy_hi - cy_lo);
     }
-  }
+    return total;
+  };
+
+  int d = 0;
+  while (d < cap && cells_covered_at(d) < (int64_t)target_partitions) d++;
 
   const double cell_size = cube_size / (double)(1 << d);
   const int grid_n = 1 << d;

--- a/src/LASRcore/FileCollection.cpp
+++ b/src/LASRcore/FileCollection.cpp
@@ -538,22 +538,12 @@ void FileCollection::add_query(double xmin, double ymin, double xmax, double yma
                                bool strict_clip,
                                double owner_xmax, double owner_ymax)
 {
-  // Reserve capacity in all four parallel vectors before mutating any of
-  // them. If any reserve throws bad_alloc, the unique_ptr below frees
-  // the shape and the catalog state is unchanged. Once all reserves
-  // succeed, the four push_backs are guaranteed allocation-free —
-  // preserving the invariant queries.size() == queries_strict_clip.size()
-  // == queries_owner_xmax.size() == queries_owner_ymax.size().
-  std::unique_ptr<Shape> rect(new Rectangle(xmin, ymin, xmax, ymax));
-  const size_t needed = queries.size() + 1;
-  queries.reserve(needed);
-  queries_strict_clip.reserve(needed);
-  queries_owner_xmax.reserve(needed);
-  queries_owner_ymax.reserve(needed);
-  queries.push_back(rect.release());
-  queries_strict_clip.push_back(strict_clip);
-  queries_owner_xmax.push_back(owner_xmax);
-  queries_owner_ymax.push_back(owner_ymax);
+  QueryRecord q;
+  q.shape       = std::unique_ptr<Shape>(new Rectangle(xmin, ymin, xmax, ymax));
+  q.strict_clip = strict_clip;
+  q.owner_xmax  = owner_xmax;
+  q.owner_ymax  = owner_ymax;
+  queries.push_back(std::move(q));
 }
 
 void FileCollection::add_query(double xcenter, double ycenter, double radius)
@@ -563,18 +553,12 @@ void FileCollection::add_query(double xcenter, double ycenter, double radius)
 
 void FileCollection::add_query(double xcenter, double ycenter, double radius, bool strict_clip)
 {
-  // Same reserve-then-push pattern as the rectangle overload above; see
-  // that comment for the invariant rationale.
-  std::unique_ptr<Shape> circ(new Circle(xcenter, ycenter, radius));
-  const size_t needed = queries.size() + 1;
-  queries.reserve(needed);
-  queries_strict_clip.reserve(needed);
-  queries_owner_xmax.reserve(needed);
-  queries_owner_ymax.reserve(needed);
-  queries.push_back(circ.release());
-  queries_strict_clip.push_back(strict_clip);
-  queries_owner_xmax.push_back(std::nan(""));
-  queries_owner_ymax.push_back(std::nan(""));
+  QueryRecord q;
+  q.shape       = std::unique_ptr<Shape>(new Circle(xcenter, ycenter, radius));
+  q.strict_clip = strict_clip;
+  // owner_xmax / owner_ymax default to NaN; circles never carry an
+  // owner override (partition_ept passes circles through unchanged).
+  queries.push_back(std::move(q));
 }
 
 bool FileCollection::add_las_file(std::string file, bool noprocess)
@@ -927,7 +911,7 @@ bool FileCollection::partition_ept(int target_partitions)
 
   bool any_partitionable = false;
   for (size_t i = 0; i < queries.size(); ++i) {
-    Shape* q = queries[i];
+    const Shape* q = queries[i].shape.get();
     if (q->type() != ShapeType::RECTANGLE) continue;
     double bxmin = std::max(q->xmin(), cxmin);
     double bymin = std::max(q->ymin(), cymin);
@@ -1043,16 +1027,18 @@ bool FileCollection::partition_ept(int target_partitions)
     }
   }
 
-  // Build replacement off-side. unique_ptrs free cleanly if anything throws.
-  std::vector<std::unique_ptr<Shape>> new_q;
-  std::vector<bool>   new_sc;
-  std::vector<double> new_ox, new_oy;
+  // Build replacement off-side. Each QueryRecord owns its shape via
+  // unique_ptr, so if any push_back throws bad_alloc the in-flight
+  // records are freed cleanly and the live queries vector is untouched.
+  std::vector<QueryRecord> replacement;
 
   auto push_passthrough = [&](size_t i) {
-    new_q.emplace_back(clone_shape(queries[i]));
-    new_sc.push_back(queries_strict_clip[i]);
-    new_ox.push_back(queries_owner_xmax[i]);
-    new_oy.push_back(queries_owner_ymax[i]);
+    QueryRecord r;
+    r.shape       = clone_shape(queries[i].shape.get());
+    r.strict_clip = queries[i].strict_clip;
+    r.owner_xmax  = queries[i].owner_xmax;
+    r.owner_ymax  = queries[i].owner_ymax;
+    replacement.push_back(std::move(r));
   };
 
   for (size_t i = 0; i < queries.size(); ++i) {
@@ -1074,28 +1060,21 @@ bool FileCollection::partition_ept(int target_partitions)
         double sxmax = std::min(cell_xmax, a.xmax);
         double symax = std::min(cell_ymax, a.ymax);
         if (sxmin >= sxmax || symin >= symax) continue;
-        new_q.emplace_back(std::unique_ptr<Shape>(
-            new Rectangle(sxmin, symin, sxmax, symax)));
-        new_sc.push_back(true);
-        new_ox.push_back(a.xmax);  // CLAMPED AOI xmax, NOT query.xmax()
-        new_oy.push_back(a.ymax);
+        QueryRecord sub;
+        sub.shape       = std::unique_ptr<Shape>(new Rectangle(sxmin, symin, sxmax, symax));
+        sub.strict_clip = true;
+        sub.owner_xmax  = a.xmax;  // CLAMPED AOI xmax, NOT query.xmax()
+        sub.owner_ymax  = a.ymax;
+        replacement.push_back(std::move(sub));
         emitted_for_this++;
       }
     }
     if (emitted_for_this == 0) push_passthrough(i);
   }
 
-  // Stage raw-pointer vector off-side so the commit is allocation-free.
-  std::vector<Shape*> raw_new;
-  raw_new.reserve(new_q.size());            // may throw bad_alloc — safe: catalog untouched
-  for (auto& up : new_q) raw_new.push_back(up.release());
-
-  // Commit (noexcept).
-  for (Shape* s : queries) delete s;
-  queries.swap(raw_new);
-  queries_strict_clip.swap(new_sc);
-  queries_owner_xmax.swap(new_ox);
-  queries_owner_ymax.swap(new_oy);
+  // Atomic commit: vector::swap is noexcept; the old QueryRecords (and
+  // their unique_ptr shapes) are destroyed when `replacement` exits scope.
+  queries.swap(replacement);
   return true;
 }
 
@@ -1205,7 +1184,8 @@ bool FileCollection::get_chunk_with_query(int i, Chunk& chunk) const
   chunk.clear();
 
   // Some shape are provided. We are performing queries i.e not processing the entire collection file by file
-  Shape* q = queries[i];
+  const QueryRecord& rec = queries[i];
+  const Shape* q = rec.shape.get();
   double minx = q->xmin();
   double miny = q->ymin();
   double maxx = q->xmax();
@@ -1241,10 +1221,10 @@ bool FileCollection::get_chunk_with_query(int i, Chunk& chunk) const
   chunk.buffer = buffer;
   chunk.catalog_xmax = xmax;
   chunk.catalog_ymax = ymax;
-  if (!std::isnan(queries_owner_xmax[i])) chunk.catalog_xmax = queries_owner_xmax[i];
-  if (!std::isnan(queries_owner_ymax[i])) chunk.catalog_ymax = queries_owner_ymax[i];
+  if (!std::isnan(rec.owner_xmax)) chunk.catalog_xmax = rec.owner_xmax;
+  if (!std::isnan(rec.owner_ymax)) chunk.catalog_ymax = rec.owner_ymax;
   chunk.shape = q->type();
-  chunk.strict_clip = queries_strict_clip[i];
+  chunk.strict_clip = rec.strict_clip;
 
   // With an R data.frame there is no file and thus no neighboring files. We can exit.
   if (use_dataframe)
@@ -1355,11 +1335,7 @@ void FileCollection::clear()
   noprocess.clear();
   files.clear();
 
-  for (auto p : queries) delete p;
-  queries.clear();
-  queries_strict_clip.clear();
-  queries_owner_xmax.clear();
-  queries_owner_ymax.clear();
+  queries.clear();  // unique_ptr in QueryRecord frees the shapes
 }
 
 bool FileCollection::file_exists(std::string& file)
@@ -1432,7 +1408,7 @@ FileCollection::FileCollection()
 
 FileCollection::~FileCollection()
 {
-  for (auto p : queries) delete p;
+  // QueryRecord destructor (unique_ptr<Shape>) handles cleanup.
 }
 
 void FileCollectionIndex::add(double xmin, double ymin, double xmax, double ymax)

--- a/src/LASRcore/FileCollection.cpp
+++ b/src/LASRcore/FileCollection.cpp
@@ -6,6 +6,10 @@
 #include "Grid.h"
 #include "PointSchema.h"
 
+#ifdef USING_GDAL
+#include <cpl_conv.h>
+#endif
+
 // To read the header of files
 #include "PCDio.h"
 #include "LASio.h"
@@ -639,6 +643,29 @@ bool FileCollection::add_ept_endpoint(std::string path, bool noprocess)
     return false;
   }
   std::replace(path.begin(), path.end(), '\\', '/');
+
+  // Tune GDAL/VSI defaults for remote EPT reads. Without these, every
+  // /vsicurl/ open does sibling-directory HEAD probing (≈10× more HTTP
+  // requests than the actual range fetch), no chunk caching means
+  // overlapping AOI sub-queries re-fetch the same bytes, and HTTP/1.1
+  // serializes per host. Measured impact on autzen-classified
+  // concurrent_files(4): warm-cache reads 42 s → 0.9 s, cold-cache
+  // reads 43 s → 13 s.
+  //
+  // CPLSetConfigOption falls through to env vars on read, so any
+  // user override (e.g. Sys.setenv) keeps precedence — only set when
+  // unset. Scope: process-wide for all subsequent VSI ops, fine for
+  // lasR's typical usage.
+#ifdef USING_GDAL
+  if (CPLGetConfigOption("GDAL_DISABLE_READDIR_ON_OPEN", nullptr) == nullptr)
+    CPLSetConfigOption("GDAL_DISABLE_READDIR_ON_OPEN", "EMPTY_DIR");
+  if (CPLGetConfigOption("GDAL_HTTP_MULTIPLEX", nullptr) == nullptr)
+    CPLSetConfigOption("GDAL_HTTP_MULTIPLEX", "YES");
+  if (CPLGetConfigOption("VSI_CACHE", nullptr) == nullptr)
+    CPLSetConfigOption("VSI_CACHE", "TRUE");
+  if (CPLGetConfigOption("VSI_CACHE_SIZE", nullptr) == nullptr)
+    CPLSetConfigOption("VSI_CACHE_SIZE", "67108864");  // 64 MiB
+#endif
 
   try {
     ept_index = EPTio::HierarchyIndex::build_metadata(path);

--- a/src/LASRcore/FileCollection.cpp
+++ b/src/LASRcore/FileCollection.cpp
@@ -19,6 +19,7 @@
 #include <cmath>
 #include <cstdint>
 #include <filesystem>
+#include <memory>
 
 // To parse JSON VPC
 #include <nlohmann/json.hpp>
@@ -868,9 +869,133 @@ bool FileCollection::partition_ept(int target_partitions)
     return true;
   }
 
-  // ---- With-queries path: stub (Task 6 fills in the partitioning).
-  // For now: leave all queries untouched so the gate accepts AOIs
-  // without crashing.
+  // ---- With-queries path ----
+
+  // Compute clamped AOI bbox per rect query and aggregate area.
+  struct AoiBbox { double xmin, ymin, xmax, ymax; bool partitionable; };
+  std::vector<AoiBbox> aoi_bboxes(queries.size(),
+      AoiBbox{0, 0, 0, 0, false});
+
+  const double cxmin = ept_index->conf_bounds[0];
+  const double cymin = ept_index->conf_bounds[1];
+  const double cxmax = ept_index->conf_bounds[3];
+  const double cymax = ept_index->conf_bounds[4];
+
+  double aoi_area = 0.0;
+  for (size_t i = 0; i < queries.size(); ++i) {
+    Shape* q = queries[i];
+    if (q->type() != ShapeType::RECTANGLE) continue;
+    double bxmin = std::max(q->xmin(), cxmin);
+    double bymin = std::max(q->ymin(), cymin);
+    double bxmax = std::min(q->xmax(), cxmax);
+    double bymax = std::min(q->ymax(), cymax);
+    if (bxmin >= bxmax || bymin >= bymax) continue;  // disjoint → passthrough
+    aoi_bboxes[i] = {bxmin, bymin, bxmax, bymax, true};
+    aoi_area += (bxmax - bxmin) * (bymax - bymin);
+  }
+
+  if (aoi_area == 0.0) return true;  // nothing partitionable; leave queries unchanged
+
+  // Depth from area ratio. Cap to min(16, max_tile_depth) BEFORE shift.
+  const double cube_size = ept_index->cube_bounds[3] - ept_index->cube_bounds[0];
+  const double cube_area = cube_size * cube_size;
+  int d = 0;
+  if (target_partitions * cube_area / aoi_area > 1.0) {
+    d = (int)std::ceil(0.5 * std::log2(target_partitions * cube_area / aoi_area));
+    if (d < 0) d = 0;
+  }
+  int max_tile_depth = 0;
+  for (const auto& t : ept_index->tiles)
+    if (t.key.d > max_tile_depth) max_tile_depth = t.key.d;
+  int cap = (max_tile_depth < 16 ? max_tile_depth : 16);
+  if (d > cap) d = cap;
+
+  const double cell_size = cube_size / (double)(1 << d);
+  const int grid_n = 1 << d;
+
+  // Cell-points map over the full 2^d × 2^d grid.
+  std::vector<int64_t> cell_points((size_t)grid_n * grid_n, 0);
+  for (const auto& t : ept_index->tiles) {
+    if (t.key.d >= d) {
+      int shift = t.key.d - d;
+      int cx = t.key.x >> shift;
+      int cy = t.key.y >> shift;
+      if (cx < 0 || cx >= grid_n || cy < 0 || cy >= grid_n) continue;
+      cell_points[(size_t)cy * grid_n + cx] += t.point_count;
+    } else {
+      int span = 1 << (d - t.key.d);
+      int cx0 = t.key.x * span;
+      int cy0 = t.key.y * span;
+      for (int iy = 0; iy < span; ++iy)
+        for (int ix = 0; ix < span; ++ix) {
+          int cx = cx0 + ix;
+          int cy = cy0 + iy;
+          if (cx < 0 || cx >= grid_n || cy < 0 || cy >= grid_n) continue;
+          cell_points[(size_t)cy * grid_n + cx] += t.point_count;
+        }
+    }
+  }
+
+  // Build replacement off-side. unique_ptrs free cleanly if anything throws.
+  std::vector<std::unique_ptr<Shape>> new_q;
+  std::vector<bool>   new_sc;
+  std::vector<double> new_ox, new_oy;
+
+  auto push_passthrough = [&](size_t i) {
+    new_q.emplace_back(clone_shape(queries[i]));
+    new_sc.push_back(queries_strict_clip[i]);
+    new_ox.push_back(queries_owner_xmax[i]);
+    new_oy.push_back(queries_owner_ymax[i]);
+  };
+
+  for (size_t i = 0; i < queries.size(); ++i) {
+    if (!aoi_bboxes[i].partitionable) { push_passthrough(i); continue; }
+
+    const AoiBbox& a = aoi_bboxes[i];
+    int cx_lo = (int)std::floor((a.xmin - ept_index->cube_bounds[0]) / cell_size);
+    int cx_hi = (int)std::ceil ((a.xmax - ept_index->cube_bounds[0]) / cell_size);
+    int cy_lo = (int)std::floor((a.ymin - ept_index->cube_bounds[1]) / cell_size);
+    int cy_hi = (int)std::ceil ((a.ymax - ept_index->cube_bounds[1]) / cell_size);
+    if (cx_lo < 0) cx_lo = 0;
+    if (cy_lo < 0) cy_lo = 0;
+    if (cx_hi > grid_n) cx_hi = grid_n;
+    if (cy_hi > grid_n) cy_hi = grid_n;
+
+    int emitted_for_this = 0;
+    for (int cy = cy_lo; cy < cy_hi; ++cy) {
+      for (int cx = cx_lo; cx < cx_hi; ++cx) {
+        if (cell_points[(size_t)cy * grid_n + cx] == 0) continue;
+        double cell_xmin = ept_index->cube_bounds[0] + cx * cell_size;
+        double cell_ymin = ept_index->cube_bounds[1] + cy * cell_size;
+        double cell_xmax = cell_xmin + cell_size;
+        double cell_ymax = cell_ymin + cell_size;
+        double sxmin = std::max(cell_xmin, a.xmin);
+        double symin = std::max(cell_ymin, a.ymin);
+        double sxmax = std::min(cell_xmax, a.xmax);
+        double symax = std::min(cell_ymax, a.ymax);
+        if (sxmin >= sxmax || symin >= symax) continue;
+        new_q.emplace_back(std::unique_ptr<Shape>(
+            new Rectangle(sxmin, symin, sxmax, symax)));
+        new_sc.push_back(true);
+        new_ox.push_back(a.xmax);  // CLAMPED AOI xmax, NOT query.xmax()
+        new_oy.push_back(a.ymax);
+        emitted_for_this++;
+      }
+    }
+    if (emitted_for_this == 0) push_passthrough(i);
+  }
+
+  // Stage raw-pointer vector off-side so the commit is allocation-free.
+  std::vector<Shape*> raw_new;
+  raw_new.reserve(new_q.size());            // may throw bad_alloc — safe: catalog untouched
+  for (auto& up : new_q) raw_new.push_back(up.release());
+
+  // Commit (noexcept).
+  for (Shape* s : queries) delete s;
+  queries.swap(raw_new);
+  queries_strict_clip.swap(new_sc);
+  queries_owner_xmax.swap(new_ox);
+  queries_owner_ymax.swap(new_oy);
   return true;
 }
 

--- a/src/LASRcore/FileCollection.cpp
+++ b/src/LASRcore/FileCollection.cpp
@@ -22,7 +22,6 @@
 #include <algorithm>
 #include <cmath>
 #include <cstdint>
-#include <cstdlib>
 #include <filesystem>
 #include <memory>
 #include <unordered_set>
@@ -667,16 +666,6 @@ bool FileCollection::add_ept_endpoint(std::string path, bool noprocess)
   if (CPLGetConfigOption("VSI_CACHE_SIZE", nullptr) == nullptr)
     CPLSetConfigOption("VSI_CACHE_SIZE", "67108864");  // 64 MiB
 #endif
-  // Suppress LASlib's per-tile HEAD size-warning. EPT tiles are small by
-  // construction; the warning was wasting one HTTP round-trip per open.
-  // setenv() is POSIX; _putenv_s() is the MSVC equivalent.
-  if (std::getenv("LASR_SKIP_REMOTE_SIZE_WARN") == nullptr) {
-#ifdef _WIN32
-    _putenv_s("LASR_SKIP_REMOTE_SIZE_WARN", "1");
-#else
-    setenv("LASR_SKIP_REMOTE_SIZE_WARN", "1", /*overwrite=*/0);
-#endif
-  }
 
   try {
     ept_index = EPTio::HierarchyIndex::build_metadata(path);

--- a/src/LASRcore/FileCollection.cpp
+++ b/src/LASRcore/FileCollection.cpp
@@ -749,15 +749,39 @@ bool FileCollection::set_chunk_size(double size, bool strict_clip)
   return true;
 }
 
+namespace {
+// Deep-copies a Shape* by dispatching on its type. Used by the
+// exception-safe rebuild in partition_ept.
+static Shape* clone_shape(const Shape* s)
+{
+  switch (s->type()) {
+    case ShapeType::RECTANGLE:
+      return new Rectangle(s->xmin(), s->ymin(), s->xmax(), s->ymax());
+    case ShapeType::CIRCLE: {
+      const Circle* c = static_cast<const Circle*>(s);
+      return new Circle(c->center.x, c->center.y, c->radius);
+    }
+    default:
+      throw std::runtime_error("clone_shape: unsupported Shape type");
+  }
+}
+}  // namespace
+
 bool FileCollection::partition_ept(int target_partitions)
 {
   if (!ept_index || get_format() != EPTFILE) return true;
-  if (queries.size() > 0) return true;
   if (chunk_size > 0) return true;
   if (target_partitions <= 0) return true;
 
+  const bool had_queries = !queries.empty();
+
+  // Hierarchy walk; with-queries fallback diverges from no-queries fallback.
   try { ept_index->ensure_tiles(); }
   catch (const std::exception& e) {
+    if (had_queries) {
+      warning("EPT hierarchy unavailable (%s); AOI partitioning skipped\n", e.what());
+      return true;
+    }
     warning("EPT hierarchy walk failed (%s); falling back to grid chunking\n", e.what());
     double dx = ept_index->conf_bounds[3] - ept_index->conf_bounds[0];
     double dy = ept_index->conf_bounds[4] - ept_index->conf_bounds[1];
@@ -766,6 +790,10 @@ bool FileCollection::partition_ept(int target_partitions)
   }
 
   if (ept_index->tiles.empty()) {
+    if (had_queries) {
+      warning("EPT hierarchy yielded no tiles; AOI partitioning skipped\n");
+      return true;
+    }
     warning("EPT hierarchy yielded no tiles; falling back to grid chunking\n");
     double dx = ept_index->conf_bounds[3] - ept_index->conf_bounds[0];
     double dy = ept_index->conf_bounds[4] - ept_index->conf_bounds[1];
@@ -773,80 +801,76 @@ bool FileCollection::partition_ept(int target_partitions)
     return set_chunk_size(size, true);
   }
 
-  // Determine partition depth d: smallest d with 4^d >= target.
-  // Cap at 16 (EPT hard depth limit) before evaluating the shift, so
-  // huge target_partitions values from test helpers cannot trigger UB.
-  int d = 0;
-  while (d < 16 && (1 << (2 * d)) < target_partitions) {
-    d++;
-  }
+  // ---- No-queries path: today's behavior, byte-for-byte ----
+  if (!had_queries) {
+    int d = 0;
+    while (d < 16 && (1 << (2 * d)) < target_partitions) d++;
+    int max_tile_depth = 0;
+    for (const auto& t : ept_index->tiles)
+      if (t.key.d > max_tile_depth) max_tile_depth = t.key.d;
+    if (d > max_tile_depth) d = max_tile_depth;
 
-  int max_tile_depth = 0;
-  for (const auto& t : ept_index->tiles)
-    if (t.key.d > max_tile_depth) max_tile_depth = t.key.d;
-  if (d > max_tile_depth) d = max_tile_depth;
+    const double cube_size = ept_index->cube_bounds[3] - ept_index->cube_bounds[0];
+    const double cell_size = cube_size / (double)(1 << d);
+    const int grid_n = 1 << d;
 
-  const double cube_size = ept_index->cube_bounds[3] - ept_index->cube_bounds[0];
-  const double cell_size = cube_size / (double)(1 << d);
-  const int grid_n = 1 << d;
-
-  std::vector<int64_t> cell_points((size_t)grid_n * grid_n, 0);
-
-  for (const auto& t : ept_index->tiles) {
-    if (t.key.d >= d) {
-      int shift = t.key.d - d;
-      int cx = t.key.x >> shift;
-      int cy = t.key.y >> shift;
-      if (cx < 0 || cx >= grid_n || cy < 0 || cy >= grid_n) continue;
-      cell_points[(size_t)cy * grid_n + cx] += t.point_count;
-    } else {
-      int span = 1 << (d - t.key.d);
-      int cx0 = t.key.x * span;
-      int cy0 = t.key.y * span;
-      for (int iy = 0; iy < span; ++iy)
-        for (int ix = 0; ix < span; ++ix) {
-          int cx = cx0 + ix;
-          int cy = cy0 + iy;
-          if (cx < 0 || cx >= grid_n || cy < 0 || cy >= grid_n) continue;
-          cell_points[(size_t)cy * grid_n + cx] += t.point_count;
-        }
+    std::vector<int64_t> cell_points((size_t)grid_n * grid_n, 0);
+    for (const auto& t : ept_index->tiles) {
+      if (t.key.d >= d) {
+        int shift = t.key.d - d;
+        int cx = t.key.x >> shift;
+        int cy = t.key.y >> shift;
+        if (cx < 0 || cx >= grid_n || cy < 0 || cy >= grid_n) continue;
+        cell_points[(size_t)cy * grid_n + cx] += t.point_count;
+      } else {
+        int span = 1 << (d - t.key.d);
+        int cx0 = t.key.x * span;
+        int cy0 = t.key.y * span;
+        for (int iy = 0; iy < span; ++iy)
+          for (int ix = 0; ix < span; ++ix) {
+            int cx = cx0 + ix;
+            int cy = cy0 + iy;
+            if (cx < 0 || cx >= grid_n || cy < 0 || cy >= grid_n) continue;
+            cell_points[(size_t)cy * grid_n + cx] += t.point_count;
+          }
+      }
     }
-  }
 
-  const double cxmin = ept_index->conf_bounds[0];
-  const double cymin = ept_index->conf_bounds[1];
-  const double cxmax = ept_index->conf_bounds[3];
-  const double cymax = ept_index->conf_bounds[4];
+    const double cxmin = ept_index->conf_bounds[0];
+    const double cymin = ept_index->conf_bounds[1];
+    const double cxmax = ept_index->conf_bounds[3];
+    const double cymax = ept_index->conf_bounds[4];
 
-  int emitted = 0;
-  for (int cy = 0; cy < grid_n; ++cy) {
-    for (int cx = 0; cx < grid_n; ++cx) {
-      if (cell_points[(size_t)cy * grid_n + cx] == 0) continue;
-
-      double cxmin_c = ept_index->cube_bounds[0] + cx * cell_size;
-      double cymin_c = ept_index->cube_bounds[1] + cy * cell_size;
-      double cxmax_c = cxmin_c + cell_size;
-      double cymax_c = cymin_c + cell_size;
-
-      if (cxmin_c < cxmin) cxmin_c = cxmin;
-      if (cymin_c < cymin) cymin_c = cymin;
-      if (cxmax_c > cxmax) cxmax_c = cxmax;
-      if (cymax_c > cymax) cymax_c = cymax;
-      if (cxmin_c >= cxmax_c || cymin_c >= cymax_c) continue;
-
-      add_query(cxmin_c, cymin_c, cxmax_c, cymax_c, true);
-      emitted++;
+    int emitted = 0;
+    for (int cy = 0; cy < grid_n; ++cy) {
+      for (int cx = 0; cx < grid_n; ++cx) {
+        if (cell_points[(size_t)cy * grid_n + cx] == 0) continue;
+        double cxmin_c = ept_index->cube_bounds[0] + cx * cell_size;
+        double cymin_c = ept_index->cube_bounds[1] + cy * cell_size;
+        double cxmax_c = cxmin_c + cell_size;
+        double cymax_c = cymin_c + cell_size;
+        if (cxmin_c < cxmin) cxmin_c = cxmin;
+        if (cymin_c < cymin) cymin_c = cymin;
+        if (cxmax_c > cxmax) cxmax_c = cxmax;
+        if (cymax_c > cymax) cymax_c = cymax;
+        if (cxmin_c >= cxmax_c || cymin_c >= cymax_c) continue;
+        add_query(cxmin_c, cymin_c, cxmax_c, cymax_c, true);
+        emitted++;
+      }
     }
+    if (emitted == 0) {
+      warning("EPT partitioning produced no chunks after conforming clamp; falling back to grid chunking\n");
+      double dx = ept_index->conf_bounds[3] - ept_index->conf_bounds[0];
+      double dy = ept_index->conf_bounds[4] - ept_index->conf_bounds[1];
+      double size = std::sqrt((dx * dy) / (double)target_partitions);
+      return set_chunk_size(size, true);
+    }
+    return true;
   }
 
-  if (emitted == 0) {
-    warning("EPT partitioning produced no chunks after conforming clamp; falling back to grid chunking\n");
-    double dx = ept_index->conf_bounds[3] - ept_index->conf_bounds[0];
-    double dy = ept_index->conf_bounds[4] - ept_index->conf_bounds[1];
-    double size = std::sqrt((dx * dy) / (double)target_partitions);
-    return set_chunk_size(size, true);
-  }
-
+  // ---- With-queries path: stub (Task 6 fills in the partitioning).
+  // For now: leave all queries untouched so the gate accepts AOIs
+  // without crashing.
   return true;
 }
 

--- a/src/LASRcore/FileCollection.cpp
+++ b/src/LASRcore/FileCollection.cpp
@@ -20,6 +20,7 @@
 #include <cstdint>
 #include <filesystem>
 #include <memory>
+#include <unordered_set>
 
 // To parse JSON VPC
 #include <nlohmann/json.hpp>
@@ -912,43 +913,95 @@ bool FileCollection::partition_ept(int target_partitions)
 
   if (aoi_area == 0.0) return true;  // nothing partitionable; leave queries unchanged
 
-  // Depth from area ratio. Cap to min(16, max_tile_depth) BEFORE shift.
+  // Depth selection — float-safe with a hard cap, then int-cast.
+  //
+  // For tiny AOIs (e.g., a sub-meter query against a 100 km cube), the
+  // ratio cube_area/aoi_area can be huge and `wanted` would overflow
+  // to inf. Converting inf to int is UB. Compare in double-space
+  // against `cap` first, only cast when finite and in range.
   const double cube_size = ept_index->cube_bounds[3] - ept_index->cube_bounds[0];
   const double cube_area = cube_size * cube_size;
-  int d = 0;
-  if (target_partitions * cube_area / aoi_area > 1.0) {
-    d = (int)std::ceil(0.5 * std::log2(target_partitions * cube_area / aoi_area));
-    if (d < 0) d = 0;
-  }
   int max_tile_depth = 0;
   for (const auto& t : ept_index->tiles)
     if (t.key.d > max_tile_depth) max_tile_depth = t.key.d;
-  int cap = (max_tile_depth < 16 ? max_tile_depth : 16);
-  if (d > cap) d = cap;
+  const int cap = (max_tile_depth < 16 ? max_tile_depth : 16);
+
+  int d;
+  {
+    const double ratio = (double)target_partitions * cube_area / aoi_area;
+    if (!std::isfinite(ratio) || ratio <= 1.0) {
+      d = 0;
+    } else {
+      const double wanted = 0.5 * std::log2(ratio);
+      if (!std::isfinite(wanted) || wanted >= (double)cap) d = cap;
+      else if (wanted < 0.0) d = 0;
+      else { d = (int)std::ceil(wanted); if (d > cap) d = cap; }
+    }
+  }
 
   const double cell_size = cube_size / (double)(1 << d);
   const int grid_n = 1 << d;
 
-  // Cell-points map over the full 2^d × 2^d grid.
-  std::vector<int64_t> cell_points((size_t)grid_n * grid_n, 0);
+  // Per-AOI cell range and union range. The cell-occupancy map is
+  // restricted to the union — memory and walk time scale with the AOI
+  // footprint, not with grid_n^2. (A naive 2^d × 2^d int64_t map would
+  // be ~32 GiB at d=16; here it's bounded by the union of AOI cell
+  // ranges, which is at most O(target_partitions) cells for a
+  // well-chosen depth.)
+  struct AoiCellRange { int cx_lo, cx_hi, cy_lo, cy_hi; };
+  std::vector<AoiCellRange> aoi_ranges(queries.size(),
+      AoiCellRange{0, 0, 0, 0});
+  int u_cx_lo = grid_n, u_cy_lo = grid_n;
+  int u_cx_hi = 0,      u_cy_hi = 0;
+  for (size_t i = 0; i < queries.size(); ++i) {
+    if (!aoi_bboxes[i].partitionable) continue;
+    const AoiBbox& a = aoi_bboxes[i];
+    int cx_lo = (int)std::floor((a.xmin - ept_index->cube_bounds[0]) / cell_size);
+    int cx_hi = (int)std::ceil ((a.xmax - ept_index->cube_bounds[0]) / cell_size);
+    int cy_lo = (int)std::floor((a.ymin - ept_index->cube_bounds[1]) / cell_size);
+    int cy_hi = (int)std::ceil ((a.ymax - ept_index->cube_bounds[1]) / cell_size);
+    if (cx_lo < 0) cx_lo = 0;
+    if (cy_lo < 0) cy_lo = 0;
+    if (cx_hi > grid_n) cx_hi = grid_n;
+    if (cy_hi > grid_n) cy_hi = grid_n;
+    aoi_ranges[i] = {cx_lo, cx_hi, cy_lo, cy_hi};
+    if (cx_lo < u_cx_lo) u_cx_lo = cx_lo;
+    if (cy_lo < u_cy_lo) u_cy_lo = cy_lo;
+    if (cx_hi > u_cx_hi) u_cx_hi = cx_hi;
+    if (cy_hi > u_cy_hi) u_cy_hi = cy_hi;
+  }
+
+  // Sparse occupancy keyed by cy * grid_n + cx. Storing the cell as a
+  // single uint64 keeps memory proportional to the number of occupied
+  // cells inside the AOI union, never to grid_n^2.
+  const uint64_t G = (uint64_t)grid_n;
+  std::unordered_set<uint64_t> occupied;
   for (const auto& t : ept_index->tiles) {
     if (t.key.d >= d) {
       int shift = t.key.d - d;
       int cx = t.key.x >> shift;
       int cy = t.key.y >> shift;
-      if (cx < 0 || cx >= grid_n || cy < 0 || cy >= grid_n) continue;
-      cell_points[(size_t)cy * grid_n + cx] += t.point_count;
+      if (cx < u_cx_lo || cx >= u_cx_hi || cy < u_cy_lo || cy >= u_cy_hi) continue;
+      occupied.insert((uint64_t)cy * G + (uint64_t)cx);
     } else {
       int span = 1 << (d - t.key.d);
       int cx0 = t.key.x * span;
       int cy0 = t.key.y * span;
-      for (int iy = 0; iy < span; ++iy)
-        for (int ix = 0; ix < span; ++ix) {
+      // Pre-clip the splat range to the AOI union. Without this, a
+      // shallow tile at depth 0 in a deep grid would iterate up to
+      // 4^d cells per tile.
+      int ix0 = std::max(0, u_cx_lo - cx0);
+      int iy0 = std::max(0, u_cy_lo - cy0);
+      int ix1 = std::min(span, u_cx_hi - cx0);
+      int iy1 = std::min(span, u_cy_hi - cy0);
+      for (int iy = iy0; iy < iy1; ++iy) {
+        for (int ix = ix0; ix < ix1; ++ix) {
           int cx = cx0 + ix;
           int cy = cy0 + iy;
           if (cx < 0 || cx >= grid_n || cy < 0 || cy >= grid_n) continue;
-          cell_points[(size_t)cy * grid_n + cx] += t.point_count;
+          occupied.insert((uint64_t)cy * G + (uint64_t)cx);
         }
+      }
     }
   }
 
@@ -967,20 +1020,13 @@ bool FileCollection::partition_ept(int target_partitions)
   for (size_t i = 0; i < queries.size(); ++i) {
     if (!aoi_bboxes[i].partitionable) { push_passthrough(i); continue; }
 
-    const AoiBbox& a = aoi_bboxes[i];
-    int cx_lo = (int)std::floor((a.xmin - ept_index->cube_bounds[0]) / cell_size);
-    int cx_hi = (int)std::ceil ((a.xmax - ept_index->cube_bounds[0]) / cell_size);
-    int cy_lo = (int)std::floor((a.ymin - ept_index->cube_bounds[1]) / cell_size);
-    int cy_hi = (int)std::ceil ((a.ymax - ept_index->cube_bounds[1]) / cell_size);
-    if (cx_lo < 0) cx_lo = 0;
-    if (cy_lo < 0) cy_lo = 0;
-    if (cx_hi > grid_n) cx_hi = grid_n;
-    if (cy_hi > grid_n) cy_hi = grid_n;
+    const AoiBbox&     a = aoi_bboxes[i];
+    const AoiCellRange r = aoi_ranges[i];
 
     int emitted_for_this = 0;
-    for (int cy = cy_lo; cy < cy_hi; ++cy) {
-      for (int cx = cx_lo; cx < cx_hi; ++cx) {
-        if (cell_points[(size_t)cy * grid_n + cx] == 0) continue;
+    for (int cy = r.cy_lo; cy < r.cy_hi; ++cy) {
+      for (int cx = r.cx_lo; cx < r.cx_hi; ++cx) {
+        if (occupied.count((uint64_t)cy * G + (uint64_t)cx) == 0) continue;
         double cell_xmin = ept_index->cube_bounds[0] + cx * cell_size;
         double cell_ymin = ept_index->cube_bounds[1] + cy * cell_size;
         double cell_xmax = cell_xmin + cell_size;

--- a/src/LASRcore/FileCollection.cpp
+++ b/src/LASRcore/FileCollection.cpp
@@ -794,6 +794,42 @@ static std::unique_ptr<Shape> clone_shape(const Shape* s)
   }
 }
 
+int FileCollection::ept_pick_depth_for_aois(
+    double cube_xmin, double cube_ymin, double cube_size,
+    int max_tile_depth, int target_partitions,
+    const std::vector<std::array<double, 4>>& aoi_bboxes)
+{
+  // Iterate octree depth `d` upward; at each `d` count the integer
+  // cells covered by the union of AOI bboxes. Stop at the smallest
+  // `d` whose total cell count meets target_partitions, capped at
+  // min(16, max_tile_depth). Monotone in `d` so at most 17 steps.
+  //
+  // The previous heuristic used an area ratio
+  //   d = ceil(0.5 * log2(target * cube_area / aoi_area))
+  // which was correct for square AOIs but undercounted long-thin
+  // ones: a 280 m × 5 m strip in a 285 m cube has tiny area but
+  // already spans the cube in x.
+  const int cap = (max_tile_depth < 16 ? max_tile_depth : 16);
+  if (cap <= 0 || target_partitions <= 0) return 0;
+
+  auto cells_at = [&](int dd) -> int64_t {
+    const double cell = cube_size / (double)(int64_t{1} << dd);
+    int64_t total = 0;
+    for (const auto& a : aoi_bboxes) {
+      int64_t cx_lo = (int64_t)std::floor((a[0] - cube_xmin) / cell);
+      int64_t cx_hi = (int64_t)std::ceil ((a[2] - cube_xmin) / cell);
+      int64_t cy_lo = (int64_t)std::floor((a[1] - cube_ymin) / cell);
+      int64_t cy_hi = (int64_t)std::ceil ((a[3] - cube_ymin) / cell);
+      total += (cx_hi - cx_lo) * (cy_hi - cy_lo);
+    }
+    return total;
+  };
+
+  int d = 0;
+  while (d < cap && cells_at(d) < (int64_t)target_partitions) d++;
+  return d;
+}
+
 bool FileCollection::partition_ept(int target_partitions)
 {
   if (!ept_index || get_format() != EPTFILE) return true;
@@ -924,42 +960,23 @@ bool FileCollection::partition_ept(int target_partitions)
 
   if (!any_partitionable) return true;  // nothing partitionable; leave queries unchanged
 
-  // Depth selection.
-  //
-  // The previous heuristic was an area ratio
-  // `d = ceil(0.5 * log2(target * cube_area / aoi_area))`. That was
-  // correct for square AOIs but undercounted long-thin AOIs: e.g. a
-  // 10 m × 1000 m AOI in a 1 km cube has 1 % area but its long axis
-  // already spans many cells at any reasonable depth, so the
-  // area-based formula could pick `d = 0` even when the AOI clearly
-  // wants several partitions.
-  //
-  // Instead, iterate `d` upward and count the integer cells covered
-  // by the (clamped) AOIs at that depth. Stop at the smallest `d`
-  // whose total cell count meets `target_partitions`, capped at
-  // min(16, max_tile_depth). Monotone in `d` so at most 17 steps.
+  // Depth selection — see ept_pick_depth_for_aois for the rationale.
+  // The previous area-ratio heuristic undercounted long-thin AOIs;
+  // the cell-count iteration is what we want.
   const double cube_size = ept_index->cube_bounds[3] - ept_index->cube_bounds[0];
   int max_tile_depth = 0;
   for (const auto& t : ept_index->tiles)
     if (t.key.d > max_tile_depth) max_tile_depth = t.key.d;
-  const int cap = (max_tile_depth < 16 ? max_tile_depth : 16);
 
-  auto cells_covered_at = [&](int dd) -> int64_t {
-    const double cell = cube_size / (double)(int64_t{1} << dd);
-    int64_t total = 0;
-    for (const auto& a : aoi_bboxes) {
-      if (!a.partitionable) continue;
-      int64_t cx_lo = (int64_t)std::floor((a.xmin - ept_index->cube_bounds[0]) / cell);
-      int64_t cx_hi = (int64_t)std::ceil ((a.xmax - ept_index->cube_bounds[0]) / cell);
-      int64_t cy_lo = (int64_t)std::floor((a.ymin - ept_index->cube_bounds[1]) / cell);
-      int64_t cy_hi = (int64_t)std::ceil ((a.ymax - ept_index->cube_bounds[1]) / cell);
-      total += (cx_hi - cx_lo) * (cy_hi - cy_lo);
-    }
-    return total;
-  };
-
-  int d = 0;
-  while (d < cap && cells_covered_at(d) < (int64_t)target_partitions) d++;
+  std::vector<std::array<double, 4>> aoi_arrays;
+  aoi_arrays.reserve(aoi_bboxes.size());
+  for (const auto& a : aoi_bboxes) {
+    if (!a.partitionable) continue;
+    aoi_arrays.push_back({a.xmin, a.ymin, a.xmax, a.ymax});
+  }
+  const int d = ept_pick_depth_for_aois(
+      ept_index->cube_bounds[0], ept_index->cube_bounds[1], cube_size,
+      max_tile_depth, target_partitions, aoi_arrays);
 
   const double cell_size = cube_size / (double)(1 << d);
   const int grid_n = 1 << d;

--- a/src/LASRcore/FileCollection.cpp
+++ b/src/LASRcore/FileCollection.cpp
@@ -669,8 +669,14 @@ bool FileCollection::add_ept_endpoint(std::string path, bool noprocess)
 #endif
   // Suppress LASlib's per-tile HEAD size-warning. EPT tiles are small by
   // construction; the warning was wasting one HTTP round-trip per open.
-  if (std::getenv("LASR_SKIP_REMOTE_SIZE_WARN") == nullptr)
+  // setenv() is POSIX; _putenv_s() is the MSVC equivalent.
+  if (std::getenv("LASR_SKIP_REMOTE_SIZE_WARN") == nullptr) {
+#ifdef _WIN32
+    _putenv_s("LASR_SKIP_REMOTE_SIZE_WARN", "1");
+#else
     setenv("LASR_SKIP_REMOTE_SIZE_WARN", "1", /*overwrite=*/0);
+#endif
+  }
 
   try {
     ept_index = EPTio::HierarchyIndex::build_metadata(path);

--- a/src/LASRcore/FileCollection.cpp
+++ b/src/LASRcore/FileCollection.cpp
@@ -528,6 +528,19 @@ void FileCollection::add_query(double xmin, double ymin, double xmax, double yma
   Rectangle* rect = new Rectangle(xmin, ymin, xmax, ymax);
   queries.push_back(rect);
   queries_strict_clip.push_back(strict_clip);
+  queries_owner_xmax.push_back(std::nan(""));
+  queries_owner_ymax.push_back(std::nan(""));
+}
+
+void FileCollection::add_query(double xmin, double ymin, double xmax, double ymax,
+                               bool strict_clip,
+                               double owner_xmax, double owner_ymax)
+{
+  Rectangle* rect = new Rectangle(xmin, ymin, xmax, ymax);
+  queries.push_back(rect);
+  queries_strict_clip.push_back(strict_clip);
+  queries_owner_xmax.push_back(owner_xmax);
+  queries_owner_ymax.push_back(owner_ymax);
 }
 
 void FileCollection::add_query(double xcenter, double ycenter, double radius)
@@ -540,6 +553,8 @@ void FileCollection::add_query(double xcenter, double ycenter, double radius, bo
   Circle* circ = new Circle(xcenter, ycenter, radius);
   queries.push_back(circ);
   queries_strict_clip.push_back(strict_clip);
+  queries_owner_xmax.push_back(std::nan(""));
+  queries_owner_ymax.push_back(std::nan(""));
 }
 
 bool FileCollection::add_las_file(std::string file, bool noprocess)
@@ -942,6 +957,8 @@ bool FileCollection::get_chunk_with_query(int i, Chunk& chunk) const
 
   chunk.catalog_xmax = xmax;
   chunk.catalog_ymax = ymax;
+  if (!std::isnan(queries_owner_xmax[i])) chunk.catalog_xmax = queries_owner_xmax[i];
+  if (!std::isnan(queries_owner_ymax[i])) chunk.catalog_ymax = queries_owner_ymax[i];
 
   // Some shape are provided. We are performing queries i.e not processing the entire collection file by file
   Shape* q = queries[i];

--- a/src/LASRcore/FileCollection.cpp
+++ b/src/LASRcore/FileCollection.cpp
@@ -759,9 +759,10 @@ bool FileCollection::partition_ept(int target_partitions)
   }
 
   // Determine partition depth d: smallest d with 4^d >= target.
+  // Cap at 16 (EPT hard depth limit) before evaluating the shift, so
+  // huge target_partitions values from test helpers cannot trigger UB.
   int d = 0;
-  while ((1 << (2 * d)) < target_partitions) {
-    if (d >= 16) break;   // EPT hard depth limit; protects shift from UB
+  while (d < 16 && (1 << (2 * d)) < target_partitions) {
     d++;
   }
 

--- a/src/LASRcore/FileCollection.cpp
+++ b/src/LASRcore/FileCollection.cpp
@@ -518,14 +518,26 @@ bool FileCollection::write_vpc(const std::string& vpcfile, const CRS& crs, bool 
 
 void FileCollection::add_query(double xmin, double ymin, double xmax, double ymax)
 {
+  add_query(xmin, ymin, xmax, ymax, false);
+}
+
+void FileCollection::add_query(double xmin, double ymin, double xmax, double ymax, bool strict_clip)
+{
   Rectangle* rect = new Rectangle(xmin, ymin, xmax, ymax);
   queries.push_back(rect);
+  queries_strict_clip.push_back(strict_clip);
 }
 
 void FileCollection::add_query(double xcenter, double ycenter, double radius)
 {
+  add_query(xcenter, ycenter, radius, false);
+}
+
+void FileCollection::add_query(double xcenter, double ycenter, double radius, bool strict_clip)
+{
   Circle* circ = new Circle(xcenter, ycenter, radius);
   queries.push_back(circ);
+  queries_strict_clip.push_back(strict_clip);
 }
 
 bool FileCollection::add_las_file(std::string file, bool noprocess)
@@ -688,6 +700,11 @@ bool FileCollection::set_noprocess(const std::vector<bool>& b)
 
 bool FileCollection::set_chunk_size(double size)
 {
+  return set_chunk_size(size, false);
+}
+
+bool FileCollection::set_chunk_size(double size, bool strict_clip)
+{
   chunk_size = 0;
 
   if (size > 0)
@@ -708,7 +725,7 @@ bool FileCollection::set_chunk_size(double size)
       double hsize = size/2;
 
       if (file_index.has_overlap(x-hsize, y-hsize, x+hsize, y+hsize))
-        add_query(x-hsize, y-hsize, x+hsize, y+hsize);
+        add_query(x-hsize, y-hsize, x+hsize, y+hsize, strict_clip);
     }
   }
 
@@ -768,6 +785,9 @@ bool FileCollection::get_chunk_regular(int i, Chunk& chunk) const
 {
   chunk.clear();
 
+  chunk.catalog_xmax = xmax;
+  chunk.catalog_ymax = ymax;
+
   const Header& h = headers[i];
 
   chunk.xmin = h.min_x;
@@ -817,6 +837,9 @@ bool FileCollection::get_chunk_with_query(int i, Chunk& chunk) const
 {
   chunk.clear();
 
+  chunk.catalog_xmax = xmax;
+  chunk.catalog_ymax = ymax;
+
   // Some shape are provided. We are performing queries i.e not processing the entire collection file by file
   Shape* q = queries[i];
   double minx = q->xmin();
@@ -853,6 +876,7 @@ bool FileCollection::get_chunk_with_query(int i, Chunk& chunk) const
   if (chunk.ymax > ymax) chunk.ymax = ymax;
   chunk.buffer = buffer;
   chunk.shape = q->type();
+  chunk.strict_clip = queries_strict_clip[i];
 
   // With an R data.frame there is no file and thus no neighboring files. We can exit.
   if (use_dataframe)
@@ -965,6 +989,7 @@ void FileCollection::clear()
 
   for (auto p : queries) delete p;
   queries.clear();
+  queries_strict_clip.clear();
 }
 
 bool FileCollection::file_exists(std::string& file)

--- a/src/LASRcore/FileCollection.cpp
+++ b/src/LASRcore/FileCollection.cpp
@@ -16,6 +16,8 @@
 #include <sstream>
 #include <iomanip>
 #include <algorithm>
+#include <cmath>
+#include <cstdint>
 #include <filesystem>
 
 // To parse JSON VPC
@@ -727,6 +729,103 @@ bool FileCollection::set_chunk_size(double size, bool strict_clip)
       if (file_index.has_overlap(x-hsize, y-hsize, x+hsize, y+hsize))
         add_query(x-hsize, y-hsize, x+hsize, y+hsize, strict_clip);
     }
+  }
+
+  return true;
+}
+
+bool FileCollection::partition_ept(int target_partitions)
+{
+  if (!ept_index || get_format() != EPTFILE) return true;
+  if (queries.size() > 0) return true;
+  if (chunk_size > 0) return true;
+  if (target_partitions <= 0) return true;
+
+  try { ept_index->ensure_tiles(); }
+  catch (const std::exception& e) {
+    warning("EPT hierarchy walk failed (%s); falling back to grid chunking\n", e.what());
+    double dx = ept_index->conf_bounds[3] - ept_index->conf_bounds[0];
+    double dy = ept_index->conf_bounds[4] - ept_index->conf_bounds[1];
+    double size = std::sqrt((dx * dy) / (double)target_partitions);
+    return set_chunk_size(size, true);
+  }
+
+  if (ept_index->tiles.empty()) {
+    warning("EPT hierarchy yielded no tiles; falling back to grid chunking\n");
+    double dx = ept_index->conf_bounds[3] - ept_index->conf_bounds[0];
+    double dy = ept_index->conf_bounds[4] - ept_index->conf_bounds[1];
+    double size = std::sqrt((dx * dy) / (double)target_partitions);
+    return set_chunk_size(size, true);
+  }
+
+  // Determine partition depth d: smallest d with 4^d >= target.
+  int d = 0;
+  while ((1 << (2 * d)) < target_partitions) d++;
+
+  int max_tile_depth = 0;
+  for (const auto& t : ept_index->tiles)
+    if (t.key.d > max_tile_depth) max_tile_depth = t.key.d;
+  if (d > max_tile_depth) d = max_tile_depth;
+
+  const double cube_size = ept_index->cube_bounds[3] - ept_index->cube_bounds[0];
+  const double cell_size = cube_size / (double)(1 << d);
+  const int grid_n = 1 << d;
+
+  std::vector<int64_t> cell_points((size_t)grid_n * grid_n, 0);
+
+  for (const auto& t : ept_index->tiles) {
+    if (t.key.d >= d) {
+      int shift = t.key.d - d;
+      int cx = t.key.x >> shift;
+      int cy = t.key.y >> shift;
+      if (cx < 0 || cx >= grid_n || cy < 0 || cy >= grid_n) continue;
+      cell_points[(size_t)cy * grid_n + cx] += t.point_count;
+    } else {
+      int span = 1 << (d - t.key.d);
+      int cx0 = t.key.x * span;
+      int cy0 = t.key.y * span;
+      for (int dy = 0; dy < span; ++dy)
+        for (int dx = 0; dx < span; ++dx) {
+          int cx = cx0 + dx;
+          int cy = cy0 + dy;
+          if (cx < 0 || cx >= grid_n || cy < 0 || cy >= grid_n) continue;
+          cell_points[(size_t)cy * grid_n + cx] += t.point_count;
+        }
+    }
+  }
+
+  const double cxmin = ept_index->conf_bounds[0];
+  const double cymin = ept_index->conf_bounds[1];
+  const double cxmax = ept_index->conf_bounds[3];
+  const double cymax = ept_index->conf_bounds[4];
+
+  int emitted = 0;
+  for (int cy = 0; cy < grid_n; ++cy) {
+    for (int cx = 0; cx < grid_n; ++cx) {
+      if (cell_points[(size_t)cy * grid_n + cx] == 0) continue;
+
+      double cxmin_c = ept_index->cube_bounds[0] + cx * cell_size;
+      double cymin_c = ept_index->cube_bounds[1] + cy * cell_size;
+      double cxmax_c = cxmin_c + cell_size;
+      double cymax_c = cymin_c + cell_size;
+
+      if (cxmin_c < cxmin) cxmin_c = cxmin;
+      if (cymin_c < cymin) cymin_c = cymin;
+      if (cxmax_c > cxmax) cxmax_c = cxmax;
+      if (cymax_c > cymax) cymax_c = cymax;
+      if (cxmin_c >= cxmax_c || cymin_c >= cymax_c) continue;
+
+      add_query(cxmin_c, cymin_c, cxmax_c, cymax_c, true);
+      emitted++;
+    }
+  }
+
+  if (emitted == 0) {
+    warning("EPT partitioning produced no chunks after conforming clamp; falling back to grid chunking\n");
+    double dx = ept_index->conf_bounds[3] - ept_index->conf_bounds[0];
+    double dy = ept_index->conf_bounds[4] - ept_index->conf_bounds[1];
+    double size = std::sqrt((dx * dy) / (double)target_partitions);
+    return set_chunk_size(size, true);
   }
 
   return true;

--- a/src/LASRcore/FileCollection.cpp
+++ b/src/LASRcore/FileCollection.cpp
@@ -589,32 +589,43 @@ bool FileCollection::add_pcd_file(std::string file, bool noprocess)
 
 bool FileCollection::add_ept_endpoint(std::string path, bool noprocess)
 {
-  if (files.size() > 0)
-  {
+  if (files.size() > 0) {
     last_error = "Only a single EPT endpoint is supported";
     return false;
   }
-
   std::replace(path.begin(), path.end(), '\\', '/');
 
-  Header header;
-  EPTio reader;
-
-  try
-  {
-    reader.open(path);
-    reader.populate_header(&header);
-    reader.close();
-  }
-  catch (const std::exception& e)
-  {
+  try {
+    ept_index = EPTio::HierarchyIndex::build_metadata(path);
+  } catch (const std::exception& e) {
     last_error = e.what();
     return false;
   }
 
+  Header header;
+  try {
+    LASio probe;
+    probe.open(ept_index->probe_tile_path);
+    probe.populate_header(&header);
+    probe.close();
+  } catch (const std::exception& e) {
+    last_error = e.what();
+    return false;
+  }
+
+  header.signature = "EPTF";
+  header.min_x = ept_index->conf_bounds[0];
+  header.min_y = ept_index->conf_bounds[1];
+  header.min_z = ept_index->conf_bounds[2];
+  header.max_x = ept_index->conf_bounds[3];
+  header.max_y = ept_index->conf_bounds[4];
+  header.max_z = ept_index->conf_bounds[5];
+  if (!ept_index->srs_wkt.empty()) header.set_crs(ept_index->srs_wkt);
+  else if (ept_index->srs_epsg > 0) header.set_crs(ept_index->srs_epsg);
+  header.spatial_index = true;
+
   add_header(header, noprocess);
   files.push_back(path);
-
   use_dataframe = false;
   return true;
 }

--- a/src/LASRcore/FileCollection.cpp
+++ b/src/LASRcore/FileCollection.cpp
@@ -751,15 +751,17 @@ bool FileCollection::set_chunk_size(double size, bool strict_clip)
 }
 
 // Deep-copies a Shape* by dispatching on its type. Used by the
-// exception-safe rebuild in partition_ept.
-static Shape* clone_shape(const Shape* s)
+// exception-safe rebuild in partition_ept. Returns unique_ptr so the
+// clone is freed if any push_back throws bad_alloc at the call site.
+static std::unique_ptr<Shape> clone_shape(const Shape* s)
 {
   switch (s->type()) {
     case ShapeType::RECTANGLE:
-      return new Rectangle(s->xmin(), s->ymin(), s->xmax(), s->ymax());
+      return std::unique_ptr<Shape>(
+          new Rectangle(s->xmin(), s->ymin(), s->xmax(), s->ymax()));
     case ShapeType::CIRCLE: {
       const Circle* c = static_cast<const Circle*>(s);
-      return new Circle(c->center.x, c->center.y, c->radius);
+      return std::unique_ptr<Shape>(new Circle(c->center.x, c->center.y, c->radius));
     }
     default:
       throw std::runtime_error("clone_shape: unsupported Shape type");

--- a/src/LASRcore/FileCollection.cpp
+++ b/src/LASRcore/FileCollection.cpp
@@ -526,19 +526,26 @@ void FileCollection::add_query(double xmin, double ymin, double xmax, double yma
 
 void FileCollection::add_query(double xmin, double ymin, double xmax, double ymax, bool strict_clip)
 {
-  Rectangle* rect = new Rectangle(xmin, ymin, xmax, ymax);
-  queries.push_back(rect);
-  queries_strict_clip.push_back(strict_clip);
-  queries_owner_xmax.push_back(std::nan(""));
-  queries_owner_ymax.push_back(std::nan(""));
+  add_query(xmin, ymin, xmax, ymax, strict_clip, std::nan(""), std::nan(""));
 }
 
 void FileCollection::add_query(double xmin, double ymin, double xmax, double ymax,
                                bool strict_clip,
                                double owner_xmax, double owner_ymax)
 {
-  Rectangle* rect = new Rectangle(xmin, ymin, xmax, ymax);
-  queries.push_back(rect);
+  // Reserve capacity in all four parallel vectors before mutating any of
+  // them. If any reserve throws bad_alloc, the unique_ptr below frees
+  // the shape and the catalog state is unchanged. Once all reserves
+  // succeed, the four push_backs are guaranteed allocation-free —
+  // preserving the invariant queries.size() == queries_strict_clip.size()
+  // == queries_owner_xmax.size() == queries_owner_ymax.size().
+  std::unique_ptr<Shape> rect(new Rectangle(xmin, ymin, xmax, ymax));
+  const size_t needed = queries.size() + 1;
+  queries.reserve(needed);
+  queries_strict_clip.reserve(needed);
+  queries_owner_xmax.reserve(needed);
+  queries_owner_ymax.reserve(needed);
+  queries.push_back(rect.release());
   queries_strict_clip.push_back(strict_clip);
   queries_owner_xmax.push_back(owner_xmax);
   queries_owner_ymax.push_back(owner_ymax);
@@ -551,8 +558,15 @@ void FileCollection::add_query(double xcenter, double ycenter, double radius)
 
 void FileCollection::add_query(double xcenter, double ycenter, double radius, bool strict_clip)
 {
-  Circle* circ = new Circle(xcenter, ycenter, radius);
-  queries.push_back(circ);
+  // Same reserve-then-push pattern as the rectangle overload above; see
+  // that comment for the invariant rationale.
+  std::unique_ptr<Shape> circ(new Circle(xcenter, ycenter, radius));
+  const size_t needed = queries.size() + 1;
+  queries.reserve(needed);
+  queries_strict_clip.reserve(needed);
+  queries_owner_xmax.reserve(needed);
+  queries_owner_ymax.reserve(needed);
+  queries.push_back(circ.release());
   queries_strict_clip.push_back(strict_clip);
   queries_owner_xmax.push_back(std::nan(""));
   queries_owner_ymax.push_back(std::nan(""));

--- a/src/LASRcore/FileCollection.cpp
+++ b/src/LASRcore/FileCollection.cpp
@@ -22,6 +22,7 @@
 #include <algorithm>
 #include <cmath>
 #include <cstdint>
+#include <cstdlib>
 #include <filesystem>
 #include <memory>
 #include <unordered_set>
@@ -666,6 +667,10 @@ bool FileCollection::add_ept_endpoint(std::string path, bool noprocess)
   if (CPLGetConfigOption("VSI_CACHE_SIZE", nullptr) == nullptr)
     CPLSetConfigOption("VSI_CACHE_SIZE", "67108864");  // 64 MiB
 #endif
+  // Suppress LASlib's per-tile HEAD size-warning. EPT tiles are small by
+  // construction; the warning was wasting one HTTP round-trip per open.
+  if (std::getenv("LASR_SKIP_REMOTE_SIZE_WARN") == nullptr)
+    setenv("LASR_SKIP_REMOTE_SIZE_WARN", "1", /*overwrite=*/0);
 
   try {
     ept_index = EPTio::HierarchyIndex::build_metadata(path);

--- a/src/LASRcore/FileCollection.cpp
+++ b/src/LASRcore/FileCollection.cpp
@@ -1104,11 +1104,6 @@ bool FileCollection::get_chunk_with_query(int i, Chunk& chunk) const
 {
   chunk.clear();
 
-  chunk.catalog_xmax = xmax;
-  chunk.catalog_ymax = ymax;
-  if (!std::isnan(queries_owner_xmax[i])) chunk.catalog_xmax = queries_owner_xmax[i];
-  if (!std::isnan(queries_owner_ymax[i])) chunk.catalog_ymax = queries_owner_ymax[i];
-
   // Some shape are provided. We are performing queries i.e not processing the entire collection file by file
   Shape* q = queries[i];
   double minx = q->xmin();
@@ -1144,6 +1139,10 @@ bool FileCollection::get_chunk_with_query(int i, Chunk& chunk) const
   if (chunk.ymin < ymin) chunk.ymin = ymin;
   if (chunk.ymax > ymax) chunk.ymax = ymax;
   chunk.buffer = buffer;
+  chunk.catalog_xmax = xmax;
+  chunk.catalog_ymax = ymax;
+  if (!std::isnan(queries_owner_xmax[i])) chunk.catalog_xmax = queries_owner_xmax[i];
+  if (!std::isnan(queries_owner_ymax[i])) chunk.catalog_ymax = queries_owner_ymax[i];
   chunk.shape = q->type();
   chunk.strict_clip = queries_strict_clip[i];
 

--- a/src/LASRcore/FileCollection.cpp
+++ b/src/LASRcore/FileCollection.cpp
@@ -838,8 +838,35 @@ bool FileCollection::partition_ept(int target_partitions)
 
   const bool had_queries = !queries.empty();
 
+  // Pre-extract AOI rectangles so the hierarchy walk can prune subtrees that
+  // sit entirely outside the AOI. Without this, a continent-scale EPT (e.g.
+  // 80B-point USGS Sierra Nevada) does a full breadth-first hierarchy
+  // enumeration before partitioning, which dominates startup. The same
+  // bboxes are recomputed inside the with-queries path below for the
+  // AoiBbox struct used by partition logic — kept local to avoid churning
+  // that block.
+  std::vector<std::array<double, 4>> walk_aoi_bboxes;
+  if (had_queries) {
+    const double cxmin0 = ept_index->conf_bounds[0];
+    const double cymin0 = ept_index->conf_bounds[1];
+    const double cxmax0 = ept_index->conf_bounds[3];
+    const double cymax0 = ept_index->conf_bounds[4];
+    walk_aoi_bboxes.reserve(queries.size());
+    for (const auto& qr : queries) {
+      const Shape* q = qr.shape.get();
+      if (q->type() != ShapeType::RECTANGLE) continue;
+      const double bxmin = std::max(q->xmin(), cxmin0);
+      const double bymin = std::max(q->ymin(), cymin0);
+      const double bxmax = std::min(q->xmax(), cxmax0);
+      const double bymax = std::min(q->ymax(), cymax0);
+      if (bxmin >= bxmax || bymin >= bymax) continue;
+      walk_aoi_bboxes.push_back({bxmin, bymin, bxmax, bymax});
+    }
+  }
+
   // Hierarchy walk; with-queries fallback diverges from no-queries fallback.
-  try { ept_index->ensure_tiles(); }
+  // The AOI filter is empty for the no-queries path (full walk, cacheable).
+  try { ept_index->ensure_tiles(walk_aoi_bboxes); }
   catch (const std::exception& e) {
     if (had_queries) {
       warning("EPT hierarchy unavailable (%s); AOI partitioning skipped\n", e.what());

--- a/src/LASRcore/FileCollection.cpp
+++ b/src/LASRcore/FileCollection.cpp
@@ -760,7 +760,10 @@ bool FileCollection::partition_ept(int target_partitions)
 
   // Determine partition depth d: smallest d with 4^d >= target.
   int d = 0;
-  while ((1 << (2 * d)) < target_partitions) d++;
+  while ((1 << (2 * d)) < target_partitions) {
+    if (d >= 16) break;   // EPT hard depth limit; protects shift from UB
+    d++;
+  }
 
   int max_tile_depth = 0;
   for (const auto& t : ept_index->tiles)
@@ -784,10 +787,10 @@ bool FileCollection::partition_ept(int target_partitions)
       int span = 1 << (d - t.key.d);
       int cx0 = t.key.x * span;
       int cy0 = t.key.y * span;
-      for (int dy = 0; dy < span; ++dy)
-        for (int dx = 0; dx < span; ++dx) {
-          int cx = cx0 + dx;
-          int cy = cy0 + dy;
+      for (int iy = 0; iy < span; ++iy)
+        for (int ix = 0; ix < span; ++ix) {
+          int cx = cx0 + ix;
+          int cy = cy0 + iy;
           if (cx < 0 || cx >= grid_n || cy < 0 || cy >= grid_n) continue;
           cell_points[(size_t)cy * grid_n + cx] += t.point_count;
         }

--- a/src/LASRcore/FileCollection.cpp
+++ b/src/LASRcore/FileCollection.cpp
@@ -749,7 +749,6 @@ bool FileCollection::set_chunk_size(double size, bool strict_clip)
   return true;
 }
 
-namespace {
 // Deep-copies a Shape* by dispatching on its type. Used by the
 // exception-safe rebuild in partition_ept.
 static Shape* clone_shape(const Shape* s)
@@ -765,7 +764,6 @@ static Shape* clone_shape(const Shape* s)
       throw std::runtime_error("clone_shape: unsupported Shape type");
   }
 }
-}  // namespace
 
 bool FileCollection::partition_ept(int target_partitions)
 {
@@ -803,6 +801,8 @@ bool FileCollection::partition_ept(int target_partitions)
 
   // ---- No-queries path: today's behavior, byte-for-byte ----
   if (!had_queries) {
+    // Cap d at 16 (EPT hard depth limit) before evaluating the shift
+    // so huge target_partitions values cannot trigger UB.
     int d = 0;
     while (d < 16 && (1 << (2 * d)) < target_partitions) d++;
     int max_tile_depth = 0;

--- a/src/LASRcore/FileCollection.cpp
+++ b/src/LASRcore/FileCollection.cpp
@@ -1110,6 +1110,8 @@ void FileCollection::clear()
   for (auto p : queries) delete p;
   queries.clear();
   queries_strict_clip.clear();
+  queries_owner_xmax.clear();
+  queries_owner_ymax.clear();
 }
 
 bool FileCollection::file_exists(std::string& file)

--- a/src/LASRcore/FileCollection.h
+++ b/src/LASRcore/FileCollection.h
@@ -9,6 +9,7 @@
 #include "Header.h"
 #include "EPTio.h"
 
+#include <cmath>
 #include <string>
 #include <vector>
 #include <filesystem>
@@ -79,6 +80,8 @@ private:
   bool get_chunk_with_query(int index, Chunk& chunk) const;
   PathType parse_path(const std::string& path);
   void add_query(double xmin, double ymin, double xmax, double ymax, bool strict_clip);
+  void add_query(double xmin, double ymin, double xmax, double ymax, bool strict_clip,
+                 double owner_xmax, double owner_ymax);  // NaN values fall through to catalog bounds
   void add_query(double xcenter, double ycenter, double radius, bool strict_clip);
 
 private:
@@ -109,6 +112,8 @@ private:
   FileCollectionIndex file_index;
   std::vector<Shape*> queries;
   std::vector<bool> queries_strict_clip;
+  std::vector<double> queries_owner_xmax;  // NaN = use catalog xmax
+  std::vector<double> queries_owner_ymax;  // NaN = use catalog ymax
 
   // EPT shared metadata index (built when add_ept_endpoint succeeds)
   std::shared_ptr<EPTio::HierarchyIndex> ept_index;

--- a/src/LASRcore/FileCollection.h
+++ b/src/LASRcore/FileCollection.h
@@ -43,6 +43,7 @@ public:
   void add_query(double xcenter, double ycenter, double radius);
   bool set_noprocess(const std::vector<bool>& b);
   bool set_chunk_size(double size);
+  bool set_chunk_size(double size, bool strict_clip);
   bool get_chunk(int index, Chunk& chunk) const;
   int get_number_chunks() const;
   int get_number_files() const;
@@ -76,6 +77,8 @@ private:
   bool get_chunk_regular(int index, Chunk& chunk) const;
   bool get_chunk_with_query(int index, Chunk& chunk) const;
   PathType parse_path(const std::string& path);
+  void add_query(double xmin, double ymin, double xmax, double ymax, bool strict_clip);
+  void add_query(double xcenter, double ycenter, double radius, bool strict_clip);
 
 private:
 
@@ -104,6 +107,7 @@ private:
   // queries, partial read
   FileCollectionIndex file_index;
   std::vector<Shape*> queries;
+  std::vector<bool> queries_strict_clip;
 
   // EPT shared metadata index (built when add_ept_endpoint succeeds)
   std::shared_ptr<EPTio::HierarchyIndex> ept_index;

--- a/src/LASRcore/FileCollection.h
+++ b/src/LASRcore/FileCollection.h
@@ -9,6 +9,7 @@
 #include "Header.h"
 #include "EPTio.h"
 
+#include <array>
 #include <cmath>
 #include <string>
 #include <vector>
@@ -65,6 +66,17 @@ public:
   bool file_exists(std::string& file);
   std::shared_ptr<const EPTio::HierarchyIndex> get_ept_index() const { return ept_index; }
   ShapeType get_query_type(int i) const { return queries[i].shape->type(); }
+
+  // Pick the octree depth at which the union of AOI bboxes (each
+  // {xmin, ymin, xmax, ymax}) covers at least `target_partitions`
+  // integer cells, capped at min(16, max_tile_depth). Used by
+  // partition_ept's with-queries path and exposed for unit tests so
+  // the same predicate can be exercised without an EPT endpoint.
+  // Returns the chosen depth; 0 ≤ d ≤ min(16, max_tile_depth).
+  static int ept_pick_depth_for_aois(
+      double cube_xmin, double cube_ymin, double cube_size,
+      int max_tile_depth, int target_partitions,
+      const std::vector<std::array<double, 4>>& aoi_bboxes);
 
   #ifdef USING_R
   void add_dataframe(double xmin, double ymin, double xmax, double ymax, int npoints);   // Special to build a FileCollection from a data.frame in R

--- a/src/LASRcore/FileCollection.h
+++ b/src/LASRcore/FileCollection.h
@@ -64,7 +64,7 @@ public:
   void clear();
   bool file_exists(std::string& file);
   std::shared_ptr<const EPTio::HierarchyIndex> get_ept_index() const { return ept_index; }
-  ShapeType get_query_type(int i) const { return queries[i]->type(); }
+  ShapeType get_query_type(int i) const { return queries[i].shape->type(); }
 
   #ifdef USING_R
   void add_dataframe(double xmin, double ymin, double xmax, double ymax, int npoints);   // Special to build a FileCollection from a data.frame in R
@@ -111,10 +111,23 @@ private:
 
   // queries, partial read
   FileCollectionIndex file_index;
-  std::vector<Shape*> queries;
-  std::vector<bool> queries_strict_clip;
-  std::vector<double> queries_owner_xmax;  // NaN = use catalog xmax
-  std::vector<double> queries_owner_ymax;  // NaN = use catalog ymax
+  // QueryRecord groups the per-query state that the four previous
+  // parallel vectors held independently. Using a struct preserves the
+  // size invariant by construction (no way to push the shape without
+  // the flags) and makes the rebuild in partition_ept a simple
+  // vector swap. The shape is owned via unique_ptr.
+  //
+  // owner_xmax / owner_ymax are NaN by default → get_chunk_with_query
+  // falls back to the catalog's xmax/ymax. AOI sub-queries emitted by
+  // partition_ept set these to the clamped AOI bbox so the strict-clip
+  // rightmost-edge carve-out fires on the AOI boundary.
+  struct QueryRecord {
+    std::unique_ptr<Shape> shape;
+    bool strict_clip = false;
+    double owner_xmax = std::nan("");
+    double owner_ymax = std::nan("");
+  };
+  std::vector<QueryRecord> queries;
 
   // EPT shared metadata index (built when add_ept_endpoint succeeds)
   std::shared_ptr<EPTio::HierarchyIndex> ept_index;

--- a/src/LASRcore/FileCollection.h
+++ b/src/LASRcore/FileCollection.h
@@ -44,6 +44,7 @@ public:
   bool set_noprocess(const std::vector<bool>& b);
   bool set_chunk_size(double size);
   bool set_chunk_size(double size, bool strict_clip);
+  bool partition_ept(int target_partitions);
   bool get_chunk(int index, Chunk& chunk) const;
   int get_number_chunks() const;
   int get_number_files() const;

--- a/src/LASRcore/FileCollection.h
+++ b/src/LASRcore/FileCollection.h
@@ -64,6 +64,7 @@ public:
   void clear();
   bool file_exists(std::string& file);
   std::shared_ptr<const EPTio::HierarchyIndex> get_ept_index() const { return ept_index; }
+  ShapeType get_query_type(int i) const { return queries[i]->type(); }
 
   #ifdef USING_R
   void add_dataframe(double xmin, double ymin, double xmax, double ymax, int npoints);   // Special to build a FileCollection from a data.frame in R

--- a/src/LASRcore/FileCollection.h
+++ b/src/LASRcore/FileCollection.h
@@ -7,10 +7,12 @@
 #include "Chunk.h"
 #include "Shape.h"
 #include "Header.h"
+#include "EPTio.h"
 
 #include <string>
 #include <vector>
 #include <filesystem>
+#include <memory>
 
 enum PathType {DIRECTORY, VPCFILE, LASFILE, LAXFILE, PCDFILE, OTHERFILE, MISSINGFILE, UNKNOWNFILE, DATAFRAME, XPTR, REMOTELASFILE, EPTFILE, REMOTEEPTFILE};
 
@@ -58,6 +60,7 @@ public:
   void set_all_indexed();
   void clear();
   bool file_exists(std::string& file);
+  std::shared_ptr<const EPTio::HierarchyIndex> get_ept_index() const { return ept_index; }
 
   #ifdef USING_R
   void add_dataframe(double xmin, double ymin, double xmax, double ymax, int npoints);   // Special to build a FileCollection from a data.frame in R
@@ -101,6 +104,9 @@ private:
   // queries, partial read
   FileCollectionIndex file_index;
   std::vector<Shape*> queries;
+
+  // EPT shared metadata index (built when add_ept_endpoint succeeds)
+  std::shared_ptr<EPTio::HierarchyIndex> ept_index;
 };
 
 #endif

--- a/src/LASRcore/parser.cpp
+++ b/src/LASRcore/parser.cpp
@@ -540,6 +540,10 @@ bool Engine::parse(const nlohmann::json& json, bool progress)
         current_crs = p->get_crs();
         p->set_filter(filters);
 
+        if (auto* eptr = dynamic_cast<LASReptreader*>(p)) {
+          eptr->set_ept_index(catalog->get_ept_index());
+        }
+
         // Create empty files that will be filled later during the processing
         if (!p->set_output_file(output)) return false;
 

--- a/src/LASRcore/print.cpp
+++ b/src/LASRcore/print.cpp
@@ -8,6 +8,7 @@
 #include <R_ext/Error.h>
 
 #include <string>
+#include <thread>
 #include <vector>
 
 #define MESSAGELVL 0
@@ -17,7 +18,14 @@
 // Global vector to store messages
 std::vector<std::pair<int, std::string>> message_queue;
 
-// Function to print and clear the queue (only called by thread 0)
+// Thread id captured at library load = the main R thread. Used to decide who
+// may touch R's C API (Rprintf/REprintf). omp_get_thread_num() is unsafe for
+// this check: it returns 0 for std::async / background threads that are not in
+// any OpenMP team, which would let them call into R off the main thread.
+static const std::thread::id g_main_thread_id = std::this_thread::get_id();
+
+// Function to print and clear the queue (only called by the main thread, under
+// the queue_mutex critical)
 void print_queue()
 {
   for (const auto &message : message_queue)
@@ -45,17 +53,18 @@ void print_queue()
 // Function to add a message to the queue
 void thread_safe_print(int level, const char *buffer)
 {
+  // A SINGLE lock guards both the push and the drain, so the global queue is
+  // never mutated concurrently. Only the main R thread drains it (i.e. touches
+  // R's C API). Previously push used critical(queue_mutex) and drain used
+  // critical(Rprint) -- two different locks on the same std::vector -- so a
+  // worker's push_back could run concurrently with the main thread's
+  // clear()/iterate, corrupting the heap under load (segfault / double free
+  // observed on large concurrent EPT reads).
   #pragma omp critical (queue_mutex)
   {
     message_queue.push_back({level, buffer});
-  }
-
-  if (omp_get_thread_num() == 0)
-  {
-    #pragma omp critical (Rprint)
-    {
+    if (std::this_thread::get_id() == g_main_thread_id)
       print_queue();
-    }
   }
 }
 

--- a/src/LASRreaders/EPTio.cpp
+++ b/src/LASRreaders/EPTio.cpp
@@ -615,7 +615,53 @@ EPTio::HierarchyIndex::build_metadata(const std::string& endpoint)
 void EPTio::HierarchyIndex::ensure_tiles()
 {
   if (tiles_built) return;
-  tiles_built = true;   // stub; full impl in Task 3
+
+  std::deque<EPTkey> pages_to_visit;
+  pages_to_visit.push_back(EPTkey(0, 0, 0, 0));
+  double cube_size = cube_bounds[3] - cube_bounds[0];
+
+  while (!pages_to_visit.empty()) {
+    EPTkey page_key = pages_to_visit.front();
+    pages_to_visit.pop_front();
+
+    std::string hier_path = base_path + "ept-hierarchy/" +
+      std::to_string(page_key.d) + "-" + std::to_string(page_key.x) + "-" +
+      std::to_string(page_key.y) + "-" + std::to_string(page_key.z) + ".json" + query_string;
+    std::string json_str;
+    bool is_root = (page_key.d == 0 && page_key.x == 0 && page_key.y == 0 && page_key.z == 0);
+    try { json_str = read_file_contents_impl(hier_path); }
+    catch (const std::exception& e) {
+      if (is_root) throw std::runtime_error("Failed to read EPT hierarchy: " + hier_path + ": " + e.what());
+      warning("EPT sub-hierarchy file not found: %s\n", hier_path.c_str());
+      continue;
+    }
+
+    nlohmann::json hierarchy = nlohmann::json::parse(json_str);
+    for (auto& [key_str, value] : hierarchy.items()) {
+      int d, x, y, z;
+      if (sscanf(key_str.c_str(), "%d-%d-%d-%d", &d, &x, &y, &z) != 4) continue;
+      EPTkey k(d, x, y, z);
+      int64_t pc = value.get<int64_t>();
+      if (pc > 0) {
+        TileEntry t;
+        t.key = k;
+        t.point_count = pc;
+        double node_size = cube_size / (1 << d);
+        t.xmin = cube_bounds[0] + x * node_size;
+        t.ymin = cube_bounds[1] + y * node_size;
+        t.zmin = cube_bounds[2] + z * node_size;
+        t.xmax = t.xmin + node_size;
+        t.ymax = t.ymin + node_size;
+        t.zmax = t.zmin + node_size;
+        tiles.push_back(t);
+        total_points += pc;
+      } else if (pc == -1) {
+        pages_to_visit.push_back(k);
+      }
+    }
+  }
+
+  tiles_built = true;
 }
 
 void EPTio::set_index(std::shared_ptr<const HierarchyIndex> idx)

--- a/src/LASRreaders/EPTio.cpp
+++ b/src/LASRreaders/EPTio.cpp
@@ -469,7 +469,7 @@ std::string EPTio::hierarchy_path(const EPTkey& key) const
     std::to_string(key.z) + ".json" + query_string;
 }
 
-std::string EPTio::read_file_contents(const std::string& path) const
+static std::string read_file_contents_impl(const std::string& path)
 {
   if (is_remote(path))
   {
@@ -506,6 +506,121 @@ std::string EPTio::read_file_contents(const std::string& path) const
   std::ostringstream ss;
   ss << file.rdbuf();
   return ss.str();
+}
+
+std::string EPTio::read_file_contents(const std::string& path) const
+{
+  return read_file_contents_impl(path);
+}
+
+std::shared_ptr<EPTio::HierarchyIndex>
+EPTio::HierarchyIndex::build_metadata(const std::string& endpoint)
+{
+  auto idx = std::make_shared<HierarchyIndex>();
+  idx->remote = is_remote(endpoint);
+
+  std::string clean_endpoint = endpoint;
+  size_t qpos = endpoint.find('?');
+  if (qpos != std::string::npos) {
+    idx->query_string = endpoint.substr(qpos);
+    clean_endpoint = endpoint.substr(0, qpos);
+  }
+
+  idx->base_path = clean_endpoint;
+  size_t pos = idx->base_path.rfind("ept.json");
+  if (pos == std::string::npos)
+    throw std::runtime_error("EPT endpoint must point to an ept.json file: " + endpoint);
+  idx->base_path = idx->base_path.substr(0, pos);
+  if (!idx->base_path.empty() && idx->base_path.back() != '/')
+    idx->base_path += '/';
+
+  // === Inline of parse_ept_json, writing into idx->* ===
+  std::string json_str = read_file_contents_impl(idx->base_path + "ept.json" + idx->query_string);
+  idx->ept_metadata = nlohmann::json::parse(json_str);
+
+  std::string data_type = idx->ept_metadata.value("dataType", "");
+  if (data_type != "laszip")
+    throw std::runtime_error("EPT dataset uses '" + data_type + "' format, only 'laszip' is supported");
+
+  auto bounds = idx->ept_metadata["bounds"];
+  if (!bounds.is_array() || bounds.size() != 6)
+    throw std::runtime_error("Invalid EPT bounds in ept.json");
+  for (int i = 0; i < 6; i++) idx->cube_bounds[i] = bounds[i].get<double>();
+
+  if (idx->ept_metadata.contains("boundsConforming")) {
+    auto cbounds = idx->ept_metadata["boundsConforming"];
+    if (cbounds.is_array() && cbounds.size() == 6) {
+      for (int i = 0; i < 6; i++) idx->conf_bounds[i] = cbounds[i].get<double>();
+    } else {
+      for (int i = 0; i < 6; i++) idx->conf_bounds[i] = idx->cube_bounds[i];
+    }
+  } else {
+    for (int i = 0; i < 6; i++) idx->conf_bounds[i] = idx->cube_bounds[i];
+  }
+
+  if (idx->ept_metadata.contains("srs")) {
+    auto srs = idx->ept_metadata["srs"];
+    idx->srs_wkt = srs.value("wkt", "");
+    std::string authority = srs.value("authority", "");
+    std::string horizontal = srs.value("horizontal", "");
+    if (idx->srs_wkt.empty() && authority == "EPSG" && !horizontal.empty()) {
+      try { idx->srs_epsg = std::stoi(horizontal); } catch (...) { idx->srs_epsg = 0; }
+    }
+  }
+
+  // === Inline of find_probe_tile, writing idx->probe_tile_path ===
+  std::deque<EPTkey> pages_to_visit;
+  pages_to_visit.push_back(EPTkey(0, 0, 0, 0));
+  while (!pages_to_visit.empty()) {
+    EPTkey page_key = pages_to_visit.front();
+    pages_to_visit.pop_front();
+
+    std::string hier_path = idx->base_path + "ept-hierarchy/" +
+      std::to_string(page_key.d) + "-" + std::to_string(page_key.x) + "-" +
+      std::to_string(page_key.y) + "-" + std::to_string(page_key.z) + ".json" + idx->query_string;
+    std::string h_str;
+    try { h_str = read_file_contents_impl(hier_path); }
+    catch (...) { continue; }
+    nlohmann::json hierarchy = nlohmann::json::parse(h_str);
+
+    for (auto& [key_str, value] : hierarchy.items()) {
+      int pc = value.get<int>();
+      if (pc <= 0) continue;
+      int d, x, y, z;
+      if (sscanf(key_str.c_str(), "%d-%d-%d-%d", &d, &x, &y, &z) != 4) continue;
+      EPTkey k(d, x, y, z);
+      double cube_size = idx->cube_bounds[3] - idx->cube_bounds[0];
+      double node_size = cube_size / (1 << d);
+      std::string path = idx->base_path + "ept-data/" +
+        std::to_string(d) + "-" + std::to_string(x) + "-" +
+        std::to_string(y) + "-" + std::to_string(z) + ".laz" + idx->query_string;
+      try {
+        LASio probe;
+        probe.open(path);
+        probe.close();
+        idx->probe_tile_path = path;
+        return idx;
+      } catch (...) { continue; }
+    }
+    for (auto& [key_str, value] : hierarchy.items()) {
+      if (value.get<int>() != -1) continue;
+      int d, x, y, z;
+      if (sscanf(key_str.c_str(), "%d-%d-%d-%d", &d, &x, &y, &z) != 4) continue;
+      pages_to_visit.push_back(EPTkey(d, x, y, z));
+    }
+  }
+  throw std::runtime_error("EPT dataset has no readable tiles to derive schema from: " + idx->base_path);
+}
+
+void EPTio::HierarchyIndex::ensure_tiles()
+{
+  if (tiles_built) return;
+  tiles_built = true;   // stub; full impl in Task 3
+}
+
+void EPTio::set_index(std::shared_ptr<const HierarchyIndex> idx)
+{
+  index = std::move(idx);
 }
 
 void EPTio::create(const std::string&)

--- a/src/LASRreaders/EPTio.cpp
+++ b/src/LASRreaders/EPTio.cpp
@@ -857,11 +857,42 @@ EPTio::HierarchyIndex::build_metadata(const std::string& endpoint)
   throw std::runtime_error("EPT dataset has no readable tiles to derive schema from: " + idx->base_path);
 }
 
-void EPTio::HierarchyIndex::ensure_tiles()
+void EPTio::HierarchyIndex::ensure_tiles(
+    const std::vector<std::array<double, 4>>& aoi_bboxes)
 {
-  if (tiles_built) return;
+  // Full-walk cache short-circuit. AOI-filtered walks deliberately do not
+  // consult or set tiles_built — see the header doc for the reuse contract.
+  if (tiles_built && aoi_bboxes.empty()) return;
+
+  // Reset before walking. `tiles` / `total_points` are append-only inside
+  // the BFS; if a previous AOI-filtered walk left partial state, a later
+  // call (any AOI scope, including the no-filter full walk) must start
+  // fresh or it will double-count or silently drop nodes outside the prior
+  // AOI from the canonical full enumeration.
+  tiles.clear();
+  total_points = 0;
 
   const double cube_size = cube_bounds[3] - cube_bounds[0];
+  const bool has_aoi_filter = !aoi_bboxes.empty();
+
+  // 2D-only AOI intersection: EPT octree z-extent is unbounded for our
+  // purposes here, and a hierarchy node's bbox spans the full cube z-range
+  // at depth 0, so we cull on xy only. This matches partition_ept's own
+  // 2D cell-occupancy logic at the call site.
+  auto key_intersects_aoi = [&](const EPTkey& k) -> bool {
+    if (!has_aoi_filter) return true;
+    const double node_size = cube_size / (double)(1 << k.d);
+    const double nxmin = cube_bounds[0] + k.x * node_size;
+    const double nymin = cube_bounds[1] + k.y * node_size;
+    const double nxmax = nxmin + node_size;
+    const double nymax = nymin + node_size;
+    for (const auto& a : aoi_bboxes) {
+      if (nxmax <= a[0] || nxmin >= a[2]) continue;
+      if (nymax <= a[1] || nymin >= a[3]) continue;
+      return true;
+    }
+    return false;
+  };
 
   // Level-synchronized BFS with concurrent fetch at each level. The
   // sequential BFS paid one HTTP RTT per sub-page; on a real remote EPT
@@ -902,6 +933,10 @@ void EPTio::HierarchyIndex::ensure_tiles()
 
       for (size_t i = batch_start; i < batch_end; ++i) {
         EPTkey k = frontier[i];
+        // Out-of-AOI subtree: skip the JSON fetch entirely. All descendants
+        // of an out-of-AOI parent are themselves out-of-AOI, so there's
+        // nothing in this branch we'd want to enumerate.
+        if (!key_intersects_aoi(k)) continue;
         fetches.push_back(std::async(std::launch::async,
           [this, k]() -> PageFetchResult {
             PageFetchResult r;
@@ -936,6 +971,12 @@ void EPTio::HierarchyIndex::ensure_tiles()
           int d, x, y, z;
           if (sscanf(key_str.c_str(), "%d-%d-%d-%d", &d, &x, &y, &z) != 4) continue;
           EPTkey k(d, x, y, z);
+          // AOI prune at child level too: a fetched parent's JSON enumerates
+          // up to 8 octree children — most may sit outside the AOI even when
+          // the parent overlaps it. Dropping them here keeps `tiles` /
+          // `next_frontier` proportional to the AOI footprint instead of
+          // the full subtree.
+          if (!key_intersects_aoi(k)) continue;
           int64_t pc = value.get<int64_t>();
           if (pc > 0) {
             TileEntry t;
@@ -959,7 +1000,10 @@ void EPTio::HierarchyIndex::ensure_tiles()
     frontier = std::move(next_frontier);
   }
 
-  tiles_built = true;
+  // Only the full walk is cacheable. An AOI-filtered run leaves a partial
+  // `tiles` set scoped to the caller's AOI — a future un-filtered call must
+  // be allowed to re-walk.
+  if (!has_aoi_filter) tiles_built = true;
 }
 
 void EPTio::set_index(std::shared_ptr<const HierarchyIndex> idx)

--- a/src/LASRreaders/EPTio.cpp
+++ b/src/LASRreaders/EPTio.cpp
@@ -11,10 +11,12 @@
 #endif
 
 #include <fstream>
+#include <future>
 #include <sstream>
 #include <algorithm>
 #include <stdexcept>
 #include <cmath>
+#include <utility>
 
 // Detect remote schemes regardless of GDAL availability so callers can produce
 // a clear "requires GDAL" error rather than letting an HTTPS URL fall through
@@ -297,6 +299,10 @@ void EPTio::query(const std::vector<std::string>& main_files,
   if (!opened)
     open(main_files[0]);
 
+  // Drain any in-flight prefetch from a prior query so it can't write
+  // into the queues we are about to reset.
+  cancel_prefetch();
+
   // Clear previous state
   tile_queue.clear();
   total_points = 0;
@@ -438,6 +444,46 @@ bool EPTio::read_point(Point* p)
   }
 }
 
+LASio* EPTio::open_tile_sync(const EPTkey& key)
+{
+  std::string path = tile_path(key);
+  LASio* tile = new LASio();
+  try
+  {
+    tile->open(path);
+    Header temp_header;
+    tile->populate_header(&temp_header);
+    return tile;
+  }
+  catch (const std::exception& e)
+  {
+    warning("Failed to open EPT tile %s: %s\n", path.c_str(), e.what());
+    delete tile;
+    return nullptr;
+  }
+}
+
+void EPTio::prefetch_next_tile()
+{
+  if (tile_queue.empty()) return;
+  EPTkey key = tile_queue.front();
+  tile_queue.pop_front();
+  next_tile_future = std::async(std::launch::async,
+    [this, key]() -> LASio* { return open_tile_sync(key); });
+}
+
+void EPTio::cancel_prefetch()
+{
+  if (!next_tile_future.valid()) return;
+  // Drain the future and discard the result (cannot cancel std::async
+  // mid-flight; we just wait it out and free the LASio if it succeeded).
+  LASio* leftover = next_tile_future.get();
+  if (leftover) {
+    leftover->close();
+    delete leftover;
+  }
+}
+
 bool EPTio::open_next_tile()
 {
   // Close previous tile
@@ -448,32 +494,33 @@ bool EPTio::open_next_tile()
     current_tile = nullptr;
   }
 
-  // No more tiles
-  if (tile_queue.empty())
-    return false;
+  // 1) Was a tile prefetched in the background? Consume that first.
+  if (next_tile_future.valid())
+  {
+    LASio* prefetched = next_tile_future.get();  // joins the worker
+    if (prefetched)
+    {
+      current_tile = prefetched;
+      // Kick off the next prefetch while the caller drains this tile.
+      prefetch_next_tile();
+      return true;
+    }
+    // Prefetch failed (warning already logged in open_tile_sync). Fall
+    // through to the queue — there may still be more tiles to try.
+  }
+
+  // 2) Synchronous open from the queue (first tile, or after a prefetch
+  //    failure with more tiles still queued).
+  if (tile_queue.empty()) return false;
 
   EPTkey key = tile_queue.front();
   tile_queue.pop_front();
+  current_tile = open_tile_sync(key);
+  if (!current_tile) return open_next_tile();  // try the next one
 
-  std::string path = tile_path(key);
-  current_tile = new LASio();
-
-  try
-  {
-    current_tile->open(path);
-    // populate_header initializes LASlib's point reader and extrabytes accessors
-    Header temp_header;
-    current_tile->populate_header(&temp_header);
-  }
-  catch (const std::exception& e)
-  {
-    warning("Failed to open EPT tile %s: %s\n", path.c_str(), e.what());
-    delete current_tile;
-    current_tile = nullptr;
-    // Try next tile
-    return open_next_tile();
-  }
-
+  // Background-fetch the tile after this one so its bytes are
+  // already arriving by the time we need it.
+  prefetch_next_tile();
   return true;
 }
 
@@ -642,49 +689,68 @@ void EPTio::HierarchyIndex::ensure_tiles()
 {
   if (tiles_built) return;
 
-  std::deque<EPTkey> pages_to_visit;
-  pages_to_visit.push_back(EPTkey(0, 0, 0, 0));
-  double cube_size = cube_bounds[3] - cube_bounds[0];
+  const double cube_size = cube_bounds[3] - cube_bounds[0];
 
-  while (!pages_to_visit.empty()) {
-    EPTkey page_key = pages_to_visit.front();
-    pages_to_visit.pop_front();
+  // Level-synchronized BFS with concurrent fetch at each level. The
+  // sequential BFS paid one HTTP RTT per sub-page; on a real remote EPT
+  // the hierarchy walk dominates first-read latency (~3 s for autzen-
+  // classified). HTTP/2 multiplex (enabled by add_ept_endpoint) lets
+  // many in-flight requests share one connection. Parsing and tile
+  // accumulation stay single-threaded so `tiles` / `total_points` need
+  // no locking.
+  std::vector<EPTkey> frontier;
+  frontier.push_back(EPTkey(0, 0, 0, 0));
 
-    std::string hier_path = base_path + "ept-hierarchy/" +
-      std::to_string(page_key.d) + "-" + std::to_string(page_key.x) + "-" +
-      std::to_string(page_key.y) + "-" + std::to_string(page_key.z) + ".json" + query_string;
-    std::string json_str;
-    bool is_root = (page_key.d == 0 && page_key.x == 0 && page_key.y == 0 && page_key.z == 0);
-    try { json_str = read_file_contents_impl(hier_path); }
-    catch (const std::exception& e) {
-      if (is_root) throw std::runtime_error("Failed to read EPT hierarchy: " + hier_path + ": " + e.what());
-      warning("EPT sub-hierarchy file not found: %s\n", hier_path.c_str());
-      continue;
+  while (!frontier.empty()) {
+    std::vector<std::future<std::pair<EPTkey, std::string>>> fetches;
+    fetches.reserve(frontier.size());
+
+    for (const EPTkey& k : frontier) {
+      fetches.push_back(std::async(std::launch::async,
+        [this, k]() -> std::pair<EPTkey, std::string> {
+          std::string path = base_path + "ept-hierarchy/" +
+            std::to_string(k.d) + "-" + std::to_string(k.x) + "-" +
+            std::to_string(k.y) + "-" + std::to_string(k.z) + ".json" + query_string;
+          try { return {k, read_file_contents_impl(path)}; }
+          catch (const std::exception& e) {
+            const bool is_root = (k.d == 0 && k.x == 0 && k.y == 0 && k.z == 0);
+            if (is_root) throw std::runtime_error("Failed to read EPT hierarchy: " + path + ": " + e.what());
+            warning("EPT sub-hierarchy file not found: %s\n", path.c_str());
+            return {k, ""};
+          }
+        }));
     }
 
-    nlohmann::json hierarchy = nlohmann::json::parse(json_str);
-    for (auto& [key_str, value] : hierarchy.items()) {
-      int d, x, y, z;
-      if (sscanf(key_str.c_str(), "%d-%d-%d-%d", &d, &x, &y, &z) != 4) continue;
-      EPTkey k(d, x, y, z);
-      int64_t pc = value.get<int64_t>();
-      if (pc > 0) {
-        TileEntry t;
-        t.key = k;
-        t.point_count = pc;
-        double node_size = cube_size / (1 << d);
-        t.xmin = cube_bounds[0] + x * node_size;
-        t.ymin = cube_bounds[1] + y * node_size;
-        t.zmin = cube_bounds[2] + z * node_size;
-        t.xmax = t.xmin + node_size;
-        t.ymax = t.ymin + node_size;
-        t.zmax = t.zmin + node_size;
-        tiles.push_back(t);
-        total_points += pc;
-      } else if (pc == -1) {
-        pages_to_visit.push_back(k);
+    std::vector<EPTkey> next_frontier;
+    for (auto& fut : fetches) {
+      std::pair<EPTkey, std::string> result = fut.get();
+      if (result.second.empty()) continue;
+
+      nlohmann::json hierarchy = nlohmann::json::parse(result.second);
+      for (auto& [key_str, value] : hierarchy.items()) {
+        int d, x, y, z;
+        if (sscanf(key_str.c_str(), "%d-%d-%d-%d", &d, &x, &y, &z) != 4) continue;
+        EPTkey k(d, x, y, z);
+        int64_t pc = value.get<int64_t>();
+        if (pc > 0) {
+          TileEntry t;
+          t.key = k;
+          t.point_count = pc;
+          double node_size = cube_size / (1 << d);
+          t.xmin = cube_bounds[0] + x * node_size;
+          t.ymin = cube_bounds[1] + y * node_size;
+          t.zmin = cube_bounds[2] + z * node_size;
+          t.xmax = t.xmin + node_size;
+          t.ymax = t.ymin + node_size;
+          t.zmax = t.zmin + node_size;
+          tiles.push_back(t);
+          total_points += pc;
+        } else if (pc == -1) {
+          next_frontier.push_back(k);
+        }
       }
     }
+    frontier = std::move(next_frontier);
   }
 
   tiles_built = true;
@@ -722,6 +788,10 @@ int64_t EPTio::p_count()
 
 void EPTio::close()
 {
+  // Drain the prefetch worker before tearing down state — its lambda
+  // captures `this` and can write into our queues if still running.
+  cancel_prefetch();
+
   if (current_tile)
   {
     current_tile->close();

--- a/src/LASRreaders/EPTio.cpp
+++ b/src/LASRreaders/EPTio.cpp
@@ -444,8 +444,9 @@ bool EPTio::read_point(Point* p)
   }
 }
 
-LASio* EPTio::open_tile_sync(const EPTkey& key)
+EPTio::TileLoadResult EPTio::open_tile_sync(const EPTkey& key)
 {
+  TileLoadResult r;
   std::string path = tile_path(key);
   LASio* tile = new LASio();
   try
@@ -453,13 +454,14 @@ LASio* EPTio::open_tile_sync(const EPTkey& key)
     tile->open(path);
     Header temp_header;
     tile->populate_header(&temp_header);
-    return tile;
+    r.tile = tile;
+    return r;
   }
   catch (const std::exception& e)
   {
-    warning("Failed to open EPT tile %s: %s\n", path.c_str(), e.what());
+    r.warning_msg = "Failed to open EPT tile " + path + ": " + e.what();
     delete tile;
-    return nullptr;
+    return r;
   }
 }
 
@@ -469,7 +471,7 @@ void EPTio::prefetch_next_tile()
   EPTkey key = tile_queue.front();
   tile_queue.pop_front();
   next_tile_future = std::async(std::launch::async,
-    [this, key]() -> LASio* { return open_tile_sync(key); });
+    [this, key]() -> TileLoadResult { return open_tile_sync(key); });
 }
 
 void EPTio::cancel_prefetch()
@@ -477,11 +479,13 @@ void EPTio::cancel_prefetch()
   if (!next_tile_future.valid()) return;
   // Drain the future and discard the result (cannot cancel std::async
   // mid-flight; we just wait it out and free the LASio if it succeeded).
-  LASio* leftover = next_tile_future.get();
-  if (leftover) {
-    leftover->close();
-    delete leftover;
+  TileLoadResult leftover = next_tile_future.get();
+  if (leftover.tile) {
+    leftover.tile->close();
+    delete leftover.tile;
   }
+  // Warning text on a leftover is harmless to drop — we already gave
+  // up on this tile.
 }
 
 bool EPTio::open_next_tile()
@@ -497,16 +501,18 @@ bool EPTio::open_next_tile()
   // 1) Was a tile prefetched in the background? Consume that first.
   if (next_tile_future.valid())
   {
-    LASio* prefetched = next_tile_future.get();  // joins the worker
-    if (prefetched)
+    TileLoadResult r = next_tile_future.get();  // joins the worker
+    if (!r.warning_msg.empty())
+      warning("%s\n", r.warning_msg.c_str());   // emitted on consumer thread
+    if (r.tile)
     {
-      current_tile = prefetched;
+      current_tile = r.tile;
       // Kick off the next prefetch while the caller drains this tile.
       prefetch_next_tile();
       return true;
     }
-    // Prefetch failed (warning already logged in open_tile_sync). Fall
-    // through to the queue — there may still be more tiles to try.
+    // Prefetch failed (warning surfaced above). Fall through to the
+    // queue — there may still be more tiles to try.
   }
 
   // 2) Synchronous open from the queue (first tile, or after a prefetch
@@ -515,8 +521,11 @@ bool EPTio::open_next_tile()
 
   EPTkey key = tile_queue.front();
   tile_queue.pop_front();
-  current_tile = open_tile_sync(key);
-  if (!current_tile) return open_next_tile();  // try the next one
+  TileLoadResult r = open_tile_sync(key);
+  if (!r.warning_msg.empty())
+    warning("%s\n", r.warning_msg.c_str());
+  if (!r.tile) return open_next_tile();  // try the next one
+  current_tile = r.tile;
 
   // Background-fetch the tile after this one so its bytes are
   // already arriving by the time we need it.
@@ -698,55 +707,89 @@ void EPTio::HierarchyIndex::ensure_tiles()
   // many in-flight requests share one connection. Parsing and tile
   // accumulation stay single-threaded so `tiles` / `total_points` need
   // no locking.
+  //
+  // Bound the number of in-flight std::async tasks per level. Without a
+  // cap, a fan-out node with hundreds of sub-pages would spawn that many
+  // OS threads at once — likely to throw std::system_error or destroy
+  // throughput via context-switch overhead. 8 matches our typical
+  // ncpu_outer_loop budget.
+  //
+  // Workers must not call warning() / Rprintf directly: that touches R's
+  // C API from a non-OpenMP thread. Errors are returned as text via the
+  // result struct and surfaced on the consumer (main) thread.
+  struct PageFetchResult {
+    EPTkey key;
+    std::string content;
+    std::string warning_msg;       // emitted by consumer thread
+    bool root_failure = false;     // root JSON missing → fatal
+    std::string root_failure_msg;
+  };
+
+  constexpr size_t max_concurrent = 8;
   std::vector<EPTkey> frontier;
   frontier.push_back(EPTkey(0, 0, 0, 0));
 
   while (!frontier.empty()) {
-    std::vector<std::future<std::pair<EPTkey, std::string>>> fetches;
-    fetches.reserve(frontier.size());
-
-    for (const EPTkey& k : frontier) {
-      fetches.push_back(std::async(std::launch::async,
-        [this, k]() -> std::pair<EPTkey, std::string> {
-          std::string path = base_path + "ept-hierarchy/" +
-            std::to_string(k.d) + "-" + std::to_string(k.x) + "-" +
-            std::to_string(k.y) + "-" + std::to_string(k.z) + ".json" + query_string;
-          try { return {k, read_file_contents_impl(path)}; }
-          catch (const std::exception& e) {
-            const bool is_root = (k.d == 0 && k.x == 0 && k.y == 0 && k.z == 0);
-            if (is_root) throw std::runtime_error("Failed to read EPT hierarchy: " + path + ": " + e.what());
-            warning("EPT sub-hierarchy file not found: %s\n", path.c_str());
-            return {k, ""};
-          }
-        }));
-    }
-
     std::vector<EPTkey> next_frontier;
-    for (auto& fut : fetches) {
-      std::pair<EPTkey, std::string> result = fut.get();
-      if (result.second.empty()) continue;
 
-      nlohmann::json hierarchy = nlohmann::json::parse(result.second);
-      for (auto& [key_str, value] : hierarchy.items()) {
-        int d, x, y, z;
-        if (sscanf(key_str.c_str(), "%d-%d-%d-%d", &d, &x, &y, &z) != 4) continue;
-        EPTkey k(d, x, y, z);
-        int64_t pc = value.get<int64_t>();
-        if (pc > 0) {
-          TileEntry t;
-          t.key = k;
-          t.point_count = pc;
-          double node_size = cube_size / (1 << d);
-          t.xmin = cube_bounds[0] + x * node_size;
-          t.ymin = cube_bounds[1] + y * node_size;
-          t.zmin = cube_bounds[2] + z * node_size;
-          t.xmax = t.xmin + node_size;
-          t.ymax = t.ymin + node_size;
-          t.zmax = t.zmin + node_size;
-          tiles.push_back(t);
-          total_points += pc;
-        } else if (pc == -1) {
-          next_frontier.push_back(k);
+    for (size_t batch_start = 0; batch_start < frontier.size(); batch_start += max_concurrent) {
+      const size_t batch_end = std::min(batch_start + max_concurrent, frontier.size());
+      std::vector<std::future<PageFetchResult>> fetches;
+      fetches.reserve(batch_end - batch_start);
+
+      for (size_t i = batch_start; i < batch_end; ++i) {
+        EPTkey k = frontier[i];
+        fetches.push_back(std::async(std::launch::async,
+          [this, k]() -> PageFetchResult {
+            PageFetchResult r;
+            r.key = k;
+            std::string path = base_path + "ept-hierarchy/" +
+              std::to_string(k.d) + "-" + std::to_string(k.x) + "-" +
+              std::to_string(k.y) + "-" + std::to_string(k.z) + ".json" + query_string;
+            try { r.content = read_file_contents_impl(path); return r; }
+            catch (const std::exception& e) {
+              const bool is_root = (k.d == 0 && k.x == 0 && k.y == 0 && k.z == 0);
+              if (is_root) {
+                r.root_failure = true;
+                r.root_failure_msg = "Failed to read EPT hierarchy: " + path + ": " + e.what();
+              } else {
+                r.warning_msg = "EPT sub-hierarchy file not found: " + path;
+              }
+              return r;
+            }
+          }));
+      }
+
+      for (auto& fut : fetches) {
+        PageFetchResult result = fut.get();
+        if (result.root_failure)
+          throw std::runtime_error(result.root_failure_msg);
+        if (!result.warning_msg.empty())
+          warning("%s\n", result.warning_msg.c_str());
+        if (result.content.empty()) continue;
+
+        nlohmann::json hierarchy = nlohmann::json::parse(result.content);
+        for (auto& [key_str, value] : hierarchy.items()) {
+          int d, x, y, z;
+          if (sscanf(key_str.c_str(), "%d-%d-%d-%d", &d, &x, &y, &z) != 4) continue;
+          EPTkey k(d, x, y, z);
+          int64_t pc = value.get<int64_t>();
+          if (pc > 0) {
+            TileEntry t;
+            t.key = k;
+            t.point_count = pc;
+            double node_size = cube_size / (1 << d);
+            t.xmin = cube_bounds[0] + x * node_size;
+            t.ymin = cube_bounds[1] + y * node_size;
+            t.zmin = cube_bounds[2] + z * node_size;
+            t.xmax = t.xmin + node_size;
+            t.ymax = t.ymin + node_size;
+            t.zmax = t.zmin + node_size;
+            tiles.push_back(t);
+            total_points += pc;
+          } else if (pc == -1) {
+            next_frontier.push_back(k);
+          }
         }
       }
     }

--- a/src/LASRreaders/EPTio.cpp
+++ b/src/LASRreaders/EPTio.cpp
@@ -14,9 +14,12 @@
 #include <future>
 #include <sstream>
 #include <algorithm>
+#include <atomic>
+#include <cstring>
 #include <stdexcept>
 #include <cmath>
 #include <utility>
+#include <vector>
 
 // Detect remote schemes regardless of GDAL availability so callers can produce
 // a clear "requires GDAL" error rather than letting an HTTPS URL fall through
@@ -44,6 +47,18 @@ EPTio::EPTio()
   total_points = 0;
   current_tile = nullptr;
   points_read = 0;
+
+  // Prefetch depth. Default 4 saturates AWS S3 from a single EPTio (matches
+  // PDAL's readers.ept requests=15 default, capped at 4 since that's the
+  // measured plateau). Env override LASR_EPT_PREFETCH clamps to [1, 32].
+  prefetch_depth = 4;
+  if (const char* env = std::getenv("LASR_EPT_PREFETCH"))
+  {
+    try {
+      int v = std::stoi(env);
+      if (v >= 1 && v <= 32) prefetch_depth = v;
+    } catch (...) { /* keep default on garbage */ }
+  }
 
   for (int i = 0; i < 6; i++)
   {
@@ -448,6 +463,107 @@ EPTio::TileLoadResult EPTio::open_tile_sync(const EPTkey& key)
 {
   TileLoadResult r;
   std::string path = tile_path(key);
+
+#ifdef USING_GDAL
+  // For remote tiles, bulk-download the .laz bytes here in the worker
+  // thread and stash them in /vsimem/. The downstream LASio::open is then
+  // a pure in-RAM operation, so the consumer's read_point() calls never
+  // hit the network. This is the single biggest source of PDAL's per-thread
+  // throughput advantage — its readers.ept does the same thing via libcurl
+  // multi-handle.
+  //
+  // Without this, the prefetch worker only fetches the LAS header (~few KB)
+  // and the bulk of the I/O still happens lazily in the consumer thread,
+  // serialized with point decoding. Empirically that limited the speedup
+  // from deepening the prefetch queue to <5%.
+  if (remote)
+  {
+    std::string vsi_url =
+      (path.compare(0, 4, "http") == 0) ? std::string("/vsicurl/") + path : path;
+
+    VSILFILE* src = VSIFOpenL(vsi_url.c_str(), "rb");
+    if (src == nullptr)
+    {
+      r.warning_msg = "Failed to open EPT tile (remote fetch) " + path;
+      return r;
+    }
+    // Read the whole file into a vector — EPT tiles are bounded by the
+    // span (typically a few MB compressed), so this is a small fixed cost.
+    VSIFSeekL(src, 0, SEEK_END);
+    vsi_l_offset sz = VSIFTellL(src);
+    VSIFSeekL(src, 0, SEEK_SET);
+    std::vector<unsigned char> buf;
+    try { buf.resize(static_cast<size_t>(sz)); }
+    catch (const std::bad_alloc&) {
+      VSIFCloseL(src);
+      r.warning_msg = "Out of memory buffering EPT tile " + path;
+      return r;
+    }
+    size_t got = (sz > 0) ? VSIFReadL(buf.data(), 1, static_cast<size_t>(sz), src) : 0;
+    VSIFCloseL(src);
+    if (got != static_cast<size_t>(sz))
+    {
+      r.warning_msg = "Short read on EPT tile " + path +
+                      " (expected " + std::to_string(sz) +
+                      ", got " + std::to_string(got) + ")";
+      return r;
+    }
+
+    // Unique /vsimem/ key. Mix tile key, EPTio instance pointer, and a
+    // process-wide atomic counter so concurrent workers (across multiple
+    // EPTio instances, multiple outer chunks) never collide.
+    static std::atomic<uint64_t> vsimem_counter{0};
+    uint64_t seq = vsimem_counter.fetch_add(1, std::memory_order_relaxed);
+    char vsimem_buf[160];
+    snprintf(vsimem_buf, sizeof(vsimem_buf),
+             "/vsimem/lasR_ept/%p_%d-%d-%d-%d_%llu.laz",
+             static_cast<const void*>(this), key.d, key.x, key.y, key.z,
+             static_cast<unsigned long long>(seq));
+    std::string vsimem_path = vsimem_buf;
+
+    // VSIFileFromMemBuffer takes ownership iff bTakeOwnership=true. We pass
+    // false and free the buffer ourselves at unlink time — except VSIFile
+    // requires a heap buffer in either case. Allocate the canonical way
+    // GDAL expects (CPLMalloc) and memcpy in. The cost vs std::move-style
+    // ownership is one extra memcpy per tile (~few MB) — negligible next
+    // to the network fetch we just saved.
+    GByte* gdal_buf = static_cast<GByte*>(CPLMalloc(static_cast<size_t>(sz)));
+    if (gdal_buf == nullptr)
+    {
+      r.warning_msg = "Out of memory staging EPT tile " + path + " in /vsimem/";
+      return r;
+    }
+    std::memcpy(gdal_buf, buf.data(), static_cast<size_t>(sz));
+    VSILFILE* mem = VSIFileFromMemBuffer(vsimem_path.c_str(), gdal_buf, sz, TRUE);
+    if (mem == nullptr)
+    {
+      CPLFree(gdal_buf);
+      r.warning_msg = "Failed to register /vsimem/ buffer for EPT tile " + path;
+      return r;
+    }
+    VSIFCloseL(mem);
+
+    LASio* tile = new LASio();
+    try
+    {
+      tile->open(vsimem_path);
+      Header temp_header;
+      tile->populate_header(&temp_header);
+      r.tile = tile;
+      r.vsimem_path = vsimem_path;
+      return r;
+    }
+    catch (const std::exception& e)
+    {
+      r.warning_msg = "Failed to open buffered EPT tile " + path + ": " + e.what();
+      delete tile;
+      VSIUnlink(vsimem_path.c_str());
+      return r;
+    }
+  }
+#endif
+
+  // Local file path — open directly, no buffering needed.
   LASio* tile = new LASio();
   try
   {
@@ -467,70 +583,97 @@ EPTio::TileLoadResult EPTio::open_tile_sync(const EPTkey& key)
 
 void EPTio::prefetch_next_tile()
 {
-  if (tile_queue.empty()) return;
-  EPTkey key = tile_queue.front();
-  tile_queue.pop_front();
-  // Prefetch is opportunistic. std::async can throw under heavy outer
-  // parallelism for two specified reasons: std::system_error when the
-  // OS refuses to spawn another thread, and std::bad_alloc when the
-  // shared state cannot be allocated. Either way we must not lose the
-  // tile — push the key back and leave next_tile_future invalid, so
-  // the next open_next_tile call falls through to the synchronous
-  // open path. Catching std::exception covers both and is harmless
-  // for any future stdlib-defined failure mode.
-  try {
-    next_tile_future = std::async(std::launch::async,
-      [this, key]() -> TileLoadResult { return open_tile_sync(key); });
-  }
-  catch (const std::exception&) {
-    tile_queue.push_front(key);
-    // next_tile_future stays invalid; consumer ignores it.
+  // Top up the prefetch queue to prefetch_depth. std::async can throw under
+  // heavy outer parallelism for two specified reasons: std::system_error
+  // when the OS refuses to spawn another thread, and std::bad_alloc when
+  // the shared state cannot be allocated. On failure we put the key back
+  // and stop refilling so the consumer falls through to a synchronous
+  // open. Catching std::exception covers both and any future failure mode.
+  while ((int)prefetch_queue.size() < prefetch_depth && !tile_queue.empty())
+  {
+    EPTkey key = tile_queue.front();
+    tile_queue.pop_front();
+    try {
+      prefetch_queue.push_back(std::async(std::launch::async,
+        [this, key]() -> TileLoadResult { return open_tile_sync(key); }));
+    }
+    catch (const std::exception&) {
+      tile_queue.push_front(key);
+      break;  // OS is refusing threads; don't keep trying this turn
+    }
   }
 }
 
 void EPTio::cancel_prefetch()
 {
-  if (!next_tile_future.valid()) return;
-  // Drain the future and discard the result (cannot cancel std::async
-  // mid-flight; we just wait it out and free the LASio if it succeeded).
-  TileLoadResult leftover = next_tile_future.get();
-  if (leftover.tile) {
-    leftover.tile->close();
-    delete leftover.tile;
+  // Drain every in-flight prefetch — cannot cancel std::async mid-flight,
+  // so we just wait them out and free any LASio they produced. Warning
+  // text on a leftover is harmless to drop; we already gave up on these.
+  // /vsimem/ buffers held by leftovers must be unlinked or they leak.
+  while (!prefetch_queue.empty())
+  {
+    TileLoadResult leftover = prefetch_queue.front().get();
+    prefetch_queue.pop_front();
+    if (leftover.tile)
+    {
+      leftover.tile->close();
+      delete leftover.tile;
+    }
+#ifdef USING_GDAL
+    if (!leftover.vsimem_path.empty())
+      VSIUnlink(leftover.vsimem_path.c_str());
+#endif
   }
-  // Warning text on a leftover is harmless to drop — we already gave
-  // up on this tile.
 }
 
 bool EPTio::open_next_tile()
 {
-  // Close previous tile
+  // Close previous tile and release its /vsimem/ buffer (if any).
   if (current_tile)
   {
     current_tile->close();
     delete current_tile;
     current_tile = nullptr;
+#ifdef USING_GDAL
+    if (!current_vsimem_path.empty())
+      VSIUnlink(current_vsimem_path.c_str());
+#endif
+    current_vsimem_path.clear();
   }
 
-  // 1) Was a tile prefetched in the background? Consume that first.
-  if (next_tile_future.valid())
+  // Keep the prefetch queue full before consuming. First call lazily
+  // populates it; subsequent calls just top it back up to depth.
+  prefetch_next_tile();
+
+  // 1) Drain prefetched tiles in order, skipping any that failed to open.
+  while (!prefetch_queue.empty())
   {
-    TileLoadResult r = next_tile_future.get();  // joins the worker
+    TileLoadResult r = prefetch_queue.front().get();
+    prefetch_queue.pop_front();
     if (!r.warning_msg.empty())
       warning("%s\n", r.warning_msg.c_str());   // emitted on consumer thread
     if (r.tile)
     {
       current_tile = r.tile;
-      // Kick off the next prefetch while the caller drains this tile.
+      current_vsimem_path = r.vsimem_path;
+      // Top up the queue so the next call already has bytes arriving.
       prefetch_next_tile();
       return true;
     }
-    // Prefetch failed (warning surfaced above). Fall through to the
-    // queue — there may still be more tiles to try.
+    // Prefetch produced no tile but may still have left a /vsimem/ key
+    // (e.g. LASio::open threw after we registered the buffer); clean it
+    // up before moving on so we don't leak in-memory bytes.
+#ifdef USING_GDAL
+    if (!r.vsimem_path.empty())
+      VSIUnlink(r.vsimem_path.c_str());
+#endif
+    // This prefetch failed — try the next one and keep the queue full.
+    prefetch_next_tile();
   }
 
-  // 2) Synchronous open from the queue (first tile, or after a prefetch
-  //    failure with more tiles still queued).
+  // 2) Synchronous open fallback (only reached if every prefetch failed
+  //    AND tile_queue is empty — i.e. the dataset is exhausted, or async
+  //    dispatch keeps failing).
   if (tile_queue.empty()) return false;
 
   EPTkey key = tile_queue.front();
@@ -538,11 +681,17 @@ bool EPTio::open_next_tile()
   TileLoadResult r = open_tile_sync(key);
   if (!r.warning_msg.empty())
     warning("%s\n", r.warning_msg.c_str());
-  if (!r.tile) return open_next_tile();  // try the next one
+  if (!r.tile)
+  {
+#ifdef USING_GDAL
+    if (!r.vsimem_path.empty())
+      VSIUnlink(r.vsimem_path.c_str());
+#endif
+    return open_next_tile();  // try the next one
+  }
   current_tile = r.tile;
+  current_vsimem_path = r.vsimem_path;
 
-  // Background-fetch the tile after this one so its bytes are
-  // already arriving by the time we need it.
   prefetch_next_tile();
   return true;
 }
@@ -854,6 +1003,11 @@ void EPTio::close()
     current_tile->close();
     delete current_tile;
     current_tile = nullptr;
+#ifdef USING_GDAL
+    if (!current_vsimem_path.empty())
+      VSIUnlink(current_vsimem_path.c_str());
+#endif
+    current_vsimem_path.clear();
   }
 
   tile_queue.clear();

--- a/src/LASRreaders/EPTio.cpp
+++ b/src/LASRreaders/EPTio.cpp
@@ -60,6 +60,23 @@ void EPTio::open(const std::string& endpoint)
   if (opened)
     throw std::logic_error("Internal error: EPTio already opened");
 
+  // Short-circuit: use metadata from index if available
+  if (index) {
+    this->remote = index->remote;
+    this->base_path = index->base_path;
+    this->query_string = index->query_string;
+    this->ept_metadata = index->ept_metadata;
+    for (int i = 0; i < 6; ++i) {
+      cube_bounds[i] = index->cube_bounds[i];
+      conf_bounds[i] = index->conf_bounds[i];
+    }
+    this->srs_wkt = index->srs_wkt;
+    this->srs_epsg = index->srs_epsg;
+    this->probe_tile_path = index->probe_tile_path;
+    opened = true;
+    return;
+  }
+
   // Determine if remote
   this->remote = is_remote(endpoint);
 
@@ -316,6 +333,15 @@ void EPTio::query(const std::vector<std::string>& main_files,
 
 void EPTio::traverse_hierarchy(double qxmin, double qymin, double qxmax, double qymax)
 {
+  if (index && index->tiles_built) {
+    for (const auto& t : index->tiles) {
+      if (depth_limit >= 0 && t.key.d > depth_limit) continue;
+      if (t.xmax < qxmin || t.xmin > qxmax || t.ymax < qymin || t.ymin > qymax) continue;
+      tile_queue.push_back(t.key);
+      total_points += t.point_count;
+    }
+    return;
+  }
   EPTkey root(0, 0, 0, 0);
   load_hierarchy_page(root, qxmin, qymin, qxmax, qymax);
 }

--- a/src/LASRreaders/EPTio.cpp
+++ b/src/LASRreaders/EPTio.cpp
@@ -470,8 +470,19 @@ void EPTio::prefetch_next_tile()
   if (tile_queue.empty()) return;
   EPTkey key = tile_queue.front();
   tile_queue.pop_front();
-  next_tile_future = std::async(std::launch::async,
-    [this, key]() -> TileLoadResult { return open_tile_sync(key); });
+  // Prefetch is opportunistic. If std::async can't spawn the thread
+  // (e.g. system_error from a resource exhaustion under heavy outer
+  // parallelism) we must not lose the tile — push the key back and
+  // leave next_tile_future invalid, so the next open_next_tile call
+  // falls through to the synchronous open path.
+  try {
+    next_tile_future = std::async(std::launch::async,
+      [this, key]() -> TileLoadResult { return open_tile_sync(key); });
+  }
+  catch (const std::system_error&) {
+    tile_queue.push_front(key);
+    // next_tile_future stays invalid; consumer ignores it.
+  }
 }
 
 void EPTio::cancel_prefetch()

--- a/src/LASRreaders/EPTio.cpp
+++ b/src/LASRreaders/EPTio.cpp
@@ -470,16 +470,19 @@ void EPTio::prefetch_next_tile()
   if (tile_queue.empty()) return;
   EPTkey key = tile_queue.front();
   tile_queue.pop_front();
-  // Prefetch is opportunistic. If std::async can't spawn the thread
-  // (e.g. system_error from a resource exhaustion under heavy outer
-  // parallelism) we must not lose the tile — push the key back and
-  // leave next_tile_future invalid, so the next open_next_tile call
-  // falls through to the synchronous open path.
+  // Prefetch is opportunistic. std::async can throw under heavy outer
+  // parallelism for two specified reasons: std::system_error when the
+  // OS refuses to spawn another thread, and std::bad_alloc when the
+  // shared state cannot be allocated. Either way we must not lose the
+  // tile — push the key back and leave next_tile_future invalid, so
+  // the next open_next_tile call falls through to the synchronous
+  // open path. Catching std::exception covers both and is harmless
+  // for any future stdlib-defined failure mode.
   try {
     next_tile_future = std::async(std::launch::async,
       [this, key]() -> TileLoadResult { return open_tile_sync(key); });
   }
-  catch (const std::system_error&) {
+  catch (const std::exception&) {
     tile_queue.push_front(key);
     // next_tile_future stays invalid; consumer ignores it.
   }

--- a/src/LASRreaders/EPTio.h
+++ b/src/LASRreaders/EPTio.h
@@ -88,10 +88,18 @@ private:
   // call from a non-OpenMP background thread, so the std::async worker
   // accumulates the message and the consumer thread emits it after
   // future.get().
+  //
+  // For remote tiles, the worker bulk-downloads the .laz bytes and stashes
+  // them in GDAL's /vsimem/ filesystem so the consumer reads from RAM
+  // (zero network on read_point). vsimem_path is the unique /vsimem/ path
+  // owned by this result — caller must VSIUnlink it after closing `tile`,
+  // because /vsimem/ files are not freed when LASio::close releases the
+  // VSI file handle.
   struct TileLoadResult
   {
     LASio* tile = nullptr;
     std::string warning_msg;
+    std::string vsimem_path;
   };
 
   void parse_ept_json();
@@ -136,13 +144,21 @@ private:
   std::deque<EPTkey> tile_queue;
   int64_t total_points;
 
-  // Current tile reader
+  // Current tile reader. For remote tiles, current_vsimem_path is the
+  // /vsimem/ key holding the buffered tile bytes — it must be VSIUnlink'd
+  // when current_tile is released (otherwise the bytes leak in GDAL's
+  // in-memory FS).
   LASio* current_tile;
-  // Background-prefetched next tile. While read_point drains current_tile,
-  // open_next_tile starts an std::async opening the next queued tile in
-  // parallel. When current_tile is exhausted we just .get() the future
-  // and swap. Single-producer single-consumer; one future per EPTio.
-  std::future<TileLoadResult> next_tile_future;
+  std::string current_vsimem_path;
+  // Background-prefetched tiles. While read_point drains current_tile,
+  // open_next_tile keeps the queue full at prefetch_depth so multiple
+  // HTTP fetches stay in flight against the EPT endpoint. AWS S3 is
+  // HTTP/1.1-only (no multiplexing), so the only way to overlap is more
+  // concurrent connections; depth=4 matches the saturation point we
+  // measured on usgs-lidar-public from us-east-2. Configurable per-process
+  // via LASR_EPT_PREFETCH env var (default 4, clamped to [1, 32]).
+  std::deque<std::future<TileLoadResult>> prefetch_queue;
+  int prefetch_depth;
   int64_t points_read;
 
   // Optional shared metadata index (Task 2+). When set via set_index, future

--- a/src/LASRreaders/EPTio.h
+++ b/src/LASRreaders/EPTio.h
@@ -83,14 +83,26 @@ public:
              std::vector<std::string> filters);
 
 private:
+  // TileLoadResult carries any warning text the worker would otherwise
+  // emit directly. R's C API (and lasR's warning() router) is not safe to
+  // call from a non-OpenMP background thread, so the std::async worker
+  // accumulates the message and the consumer thread emits it after
+  // future.get().
+  struct TileLoadResult
+  {
+    LASio* tile = nullptr;
+    std::string warning_msg;
+  };
+
   void parse_ept_json();
   void traverse_hierarchy(double qxmin, double qymin, double qxmax, double qymax);
   void load_hierarchy_page(const EPTkey& key, double qxmin, double qymin, double qxmax, double qymax);
   bool open_next_tile();
   // open_tile_sync constructs a LASio at the given key, opens it, and
   // populates the header (so the caller does not block on it again).
-  // Returns nullptr on failure (with a warning logged).
-  LASio* open_tile_sync(const EPTkey& key);
+  // Safe to call from a background thread: warning text is returned in
+  // TileLoadResult::warning_msg rather than emitted directly.
+  TileLoadResult open_tile_sync(const EPTkey& key);
   void prefetch_next_tile();
   void cancel_prefetch();
   std::string read_file_contents(const std::string& path) const;
@@ -130,7 +142,7 @@ private:
   // open_next_tile starts an std::async opening the next queued tile in
   // parallel. When current_tile is exhausted we just .get() the future
   // and swap. Single-producer single-consumer; one future per EPTio.
-  std::future<LASio*> next_tile_future;
+  std::future<TileLoadResult> next_tile_future;
   int64_t points_read;
 
   // Optional shared metadata index (Task 2+). When set via set_index, future

--- a/src/LASRreaders/EPTio.h
+++ b/src/LASRreaders/EPTio.h
@@ -10,6 +10,7 @@
 #include <vector>
 #include <deque>
 #include <cstdint>
+#include <memory>
 
 class LASio;
 class Header;
@@ -31,6 +32,33 @@ public:
     EPTkey(int d, int x, int y, int z) : d(d), x(x), y(y), z(z) {}
   };
 
+  struct TileEntry
+  {
+    EPTkey key;
+    int64_t point_count;
+    double xmin, ymin, zmin, xmax, ymax, zmax;
+  };
+
+  struct HierarchyIndex
+  {
+    nlohmann::json ept_metadata;
+    double cube_bounds[6];
+    double conf_bounds[6];
+    std::string srs_wkt;
+    int srs_epsg = 0;
+    std::string base_path;
+    std::string query_string;
+    bool remote = false;
+    std::string probe_tile_path;
+
+    std::vector<TileEntry> tiles;
+    int64_t total_points = 0;
+    bool tiles_built = false;
+
+    static std::shared_ptr<HierarchyIndex> build_metadata(const std::string& endpoint);
+    void ensure_tiles();
+  };
+
   EPTio();
   ~EPTio();
   void open(const std::string& endpoint) override;
@@ -45,6 +73,7 @@ public:
   int64_t p_count() override;
 
   void set_depth(int depth);
+  void set_index(std::shared_ptr<const HierarchyIndex> idx);
 
   void query(const std::vector<std::string>& main_files,
              const std::vector<std::string>& neighbour_files,
@@ -91,6 +120,11 @@ private:
   // Current tile reader
   LASio* current_tile;
   int64_t points_read;
+
+  // Optional shared metadata index (Task 2+). When set via set_index, future
+  // tasks will use this to share metadata across per-chunk readers; currently
+  // unused by the existing read path.
+  std::shared_ptr<const HierarchyIndex> index;
 };
 
 #endif

--- a/src/LASRreaders/EPTio.h
+++ b/src/LASRreaders/EPTio.h
@@ -12,6 +12,7 @@
 #include <cstdint>
 #include <future>
 #include <memory>
+#include <array>
 
 class LASio;
 class Header;
@@ -57,7 +58,19 @@ public:
     bool tiles_built = false;
 
     static std::shared_ptr<HierarchyIndex> build_metadata(const std::string& endpoint);
-    void ensure_tiles();
+
+    // Walk the EPT hierarchy from the root, populating `tiles` and
+    // `total_points`. The default (no AOI filter) caches the full walk via
+    // `tiles_built` so subsequent calls are no-ops.
+    //
+    // When `aoi_bboxes` is non-empty, prune the BFS to subtrees whose node
+    // bbox intersects any rect in {xmin,ymin,xmax,ymax}. This is the fast
+    // path for partition_ept on huge EPTs (e.g. continent-scale archives)
+    // where enumerating the full hierarchy would dominate startup. The
+    // result is NOT cached: tiles_built stays false so a later un-filtered
+    // call still walks everything. Callers must reuse only inside the same
+    // logical AOI scope.
+    void ensure_tiles(const std::vector<std::array<double, 4>>& aoi_bboxes = {});
   };
 
   EPTio();

--- a/src/LASRreaders/EPTio.h
+++ b/src/LASRreaders/EPTio.h
@@ -10,6 +10,7 @@
 #include <vector>
 #include <deque>
 #include <cstdint>
+#include <future>
 #include <memory>
 
 class LASio;
@@ -86,6 +87,12 @@ private:
   void traverse_hierarchy(double qxmin, double qymin, double qxmax, double qymax);
   void load_hierarchy_page(const EPTkey& key, double qxmin, double qymin, double qxmax, double qymax);
   bool open_next_tile();
+  // open_tile_sync constructs a LASio at the given key, opens it, and
+  // populates the header (so the caller does not block on it again).
+  // Returns nullptr on failure (with a warning logged).
+  LASio* open_tile_sync(const EPTkey& key);
+  void prefetch_next_tile();
+  void cancel_prefetch();
   std::string read_file_contents(const std::string& path) const;
   std::string tile_path(const EPTkey& key) const;
   std::string hierarchy_path(const EPTkey& key) const;
@@ -119,6 +126,11 @@ private:
 
   // Current tile reader
   LASio* current_tile;
+  // Background-prefetched next tile. While read_point drains current_tile,
+  // open_next_tile starts an std::async opening the next queued tile in
+  // parallel. When current_tile is exhausted we just .get() the future
+  // and swap. Single-producer single-consumer; one future per EPTio.
+  std::future<LASio*> next_tile_future;
   int64_t points_read;
 
   // Optional shared metadata index (Task 2+). When set via set_index, future

--- a/src/LASRstages/callback.cpp
+++ b/src/LASRstages/callback.cpp
@@ -345,7 +345,13 @@ bool LASRcallback::process(PointCloud*& las)
       int i = 0;
       while (las->read_point())
       {
-        bool buffer = las->point.inside_buffer(xmin, ymin, xmax, ymax, circular);
+        // Honor the reader-set buffered flag first (strict-clip mode in
+        // EPTio marks interior-edge points as BUFFERED that geometric
+        // inside_buffer would call CORE). Falling through to the
+        // geometric recompute keeps non-EPT readers (which set the flag
+        // from inside_buffer themselves) working the same as before.
+        bool buffer = las->point.get_buffered() ||
+                      las->point.inside_buffer(xmin, ymin, xmax, ymax, circular);
         if (drop_buffer && buffer) continue;
 
         // for each element of the list

--- a/src/LASRstages/readept.cpp
+++ b/src/LASRstages/readept.cpp
@@ -9,6 +9,21 @@ LASReptreader::LASReptreader()
   streaming = true;
 }
 
+LASReptreader::StrictClipDecision LASReptreader::strict_clip_decide(
+    double px, double py,
+    double xmin, double xmax, double ymin, double ymax,
+    double buffer, double catalog_xmax, double catalog_ymax)
+{
+  const double bxmin = xmin - buffer;
+  const double bxmax = xmax + buffer;
+  const double bymin = ymin - buffer;
+  const double bymax = ymax + buffer;
+  if (px < bxmin || px > bxmax || py < bymin || py > bymax) return DROP;
+  bool owns_x = (px >= xmin) && (px < xmax || (px == xmax && xmax == catalog_xmax));
+  bool owns_y = (py >= ymin) && (py < ymax || (py == ymax && ymax == catalog_ymax));
+  return (owns_x && owns_y) ? CORE : BUFFERED;
+}
+
 bool LASReptreader::set_chunk(Chunk& chunk)
 {
   Stage::set_chunk(chunk);
@@ -83,16 +98,12 @@ bool LASReptreader::process(Point*& point)
     }
 
     if (chunk_strict_clip) {
-      const double bxmin = xmin - buffer;
-      const double bxmax = xmax + buffer;
-      const double bymin = ymin - buffer;
-      const double bymax = ymax + buffer;
-      const double px = point->get_x();
-      const double py = point->get_y();
-      if (px < bxmin || px > bxmax || py < bymin || py > bymax) continue;  // re-read
-      bool owns_x = (px >= xmin) && (px < xmax || (px == xmax && xmax == catalog_xmax));
-      bool owns_y = (py >= ymin) && (py < ymax || (py == ymax && ymax == catalog_ymax));
-      if (!(owns_x && owns_y)) point->set_buffered();
+      auto decision = strict_clip_decide(
+          point->get_x(), point->get_y(),
+          xmin, xmax, ymin, ymax, buffer,
+          catalog_xmax, catalog_ymax);
+      if (decision == DROP) continue;  // re-read
+      if (decision == BUFFERED) point->set_buffered();
     } else {
       if (point->inside_buffer(xmin, ymin, xmax, ymax, circular))
         point->set_buffered();
@@ -122,16 +133,12 @@ bool LASReptreader::process(PointCloud*& las)
     if (pointfilter.filter(&p)) continue;
 
     if (chunk_strict_clip) {
-      const double bxmin = xmin - buffer;
-      const double bxmax = xmax + buffer;
-      const double bymin = ymin - buffer;
-      const double bymax = ymax + buffer;
-      const double px = p.get_x();
-      const double py = p.get_y();
-      if (px < bxmin || px > bxmax || py < bymin || py > bymax) continue;
-      bool owns_x = (px >= xmin) && (px < xmax || (px == xmax && xmax == catalog_xmax));
-      bool owns_y = (py >= ymin) && (py < ymax || (py == ymax && ymax == catalog_ymax));
-      if (!(owns_x && owns_y)) p.set_buffered();
+      auto decision = strict_clip_decide(
+          p.get_x(), p.get_y(),
+          xmin, xmax, ymin, ymax, buffer,
+          catalog_xmax, catalog_ymax);
+      if (decision == DROP) continue;
+      if (decision == BUFFERED) p.set_buffered();
     } else if (p.inside_buffer(xmin, ymin, xmax, ymax, circular)) {
       p.set_buffered();
     }

--- a/src/LASRstages/readept.cpp
+++ b/src/LASRstages/readept.cpp
@@ -73,24 +73,34 @@ bool LASReptreader::process(Header*& header)
 // Streaming mode
 bool LASReptreader::process(Point*& point)
 {
-  if (point == nullptr)
-    point = new Point(&header->schema);
+  if (point == nullptr) point = new Point(&header->schema);
 
-  do
-  {
-    if (eptio->read_point(point))
-    {
+  while (true) {
+    if (!eptio->read_point(point)) {
+      delete point;
+      point = nullptr;
+      return true;
+    }
+
+    if (chunk_strict_clip) {
+      const double bxmin = xmin - buffer;
+      const double bxmax = xmax + buffer;
+      const double bymin = ymin - buffer;
+      const double bymax = ymax + buffer;
+      const double px = point->get_x();
+      const double py = point->get_y();
+      if (px < bxmin || px > bxmax || py < bymin || py > bymax) continue;  // re-read
+      bool owns_x = (px >= xmin) && (px < xmax || (px == xmax && xmax == catalog_xmax));
+      bool owns_y = (py >= ymin) && (py < ymax || (py == ymax && ymax == catalog_ymax));
+      if (!(owns_x && owns_y)) point->set_buffered();
+    } else {
       if (point->inside_buffer(xmin, ymin, xmax, ymax, circular))
         point->set_buffered();
     }
-    else
-    {
-      delete point;
-      point = nullptr;
-    }
-  } while (point != nullptr && pointfilter.filter(point));
 
-  return true;
+    if (pointfilter.filter(point)) continue;  // re-read on filter reject
+    return true;
+  }
 }
 
 // In memory mode
@@ -107,13 +117,26 @@ bool LASReptreader::process(PointCloud*& las)
 
   Point p(&header->schema);
 
-  while (eptio->read_point(&p))
-  {
+  while (eptio->read_point(&p)) {
     if (progress->interrupted()) break;
     if (pointfilter.filter(&p)) continue;
-    if (p.inside_buffer(xmin, ymin, xmax, ymax, circular)) p.set_buffered();
-    if (!las->add_point(p)) return false;
 
+    if (chunk_strict_clip) {
+      const double bxmin = xmin - buffer;
+      const double bxmax = xmax + buffer;
+      const double bymin = ymin - buffer;
+      const double bymax = ymax + buffer;
+      const double px = p.get_x();
+      const double py = p.get_y();
+      if (px < bxmin || px > bxmax || py < bymin || py > bymax) continue;
+      bool owns_x = (px >= xmin) && (px < xmax || (px == xmax && xmax == catalog_xmax));
+      bool owns_y = (py >= ymin) && (py < ymax || (py == ymax && ymax == catalog_ymax));
+      if (!(owns_x && owns_y)) p.set_buffered();
+    } else if (p.inside_buffer(xmin, ymin, xmax, ymax, circular)) {
+      p.set_buffered();
+    }
+
+    if (!las->add_point(p)) return false;
     progress->update(eptio->p_count());
     progress->show();
   }

--- a/src/LASRstages/readept.cpp
+++ b/src/LASRstages/readept.cpp
@@ -22,6 +22,11 @@ bool LASReptreader::set_chunk(Chunk& chunk)
 
   eptio = new EPTio();
 
+  if (ept_index) eptio->set_index(ept_index);
+  chunk_strict_clip = chunk.strict_clip;
+  catalog_xmax = chunk.catalog_xmax;
+  catalog_ymax = chunk.catalog_ymax;
+
   try
   {
     eptio->query(

--- a/src/LASRstages/readept.h
+++ b/src/LASRstages/readept.h
@@ -39,6 +39,7 @@ private:
   bool streaming;
   std::shared_ptr<const EPTio::HierarchyIndex> ept_index;
   bool chunk_strict_clip = false;
+  // See Chunk::catalog_xmax for semantic.
   double catalog_xmax = 0;
   double catalog_ymax = 0;
 };

--- a/src/LASRstages/readept.h
+++ b/src/LASRstages/readept.h
@@ -26,6 +26,13 @@ public:
 
   void set_ept_index(std::shared_ptr<const EPTio::HierarchyIndex> idx) { ept_index = std::move(idx); }
 
+  // Per-point ownership decision under chunk.strict_clip.
+  enum StrictClipDecision { DROP, CORE, BUFFERED };
+  static StrictClipDecision strict_clip_decide(
+      double px, double py,
+      double xmin, double xmax, double ymin, double ymax,
+      double buffer, double catalog_xmax, double catalog_ymax);
+
 private:
   Header* header;
   EPTio* eptio;

--- a/src/LASRstages/readept.h
+++ b/src/LASRstages/readept.h
@@ -2,6 +2,8 @@
 #define LASRREADEPT_H
 
 #include "Stage.h"
+#include <memory>
+#include "EPTio.h"
 
 class EPTio;
 
@@ -22,10 +24,16 @@ public:
   // multi-threading
   LASReptreader* clone() const override { return new LASReptreader(*this); };
 
+  void set_ept_index(std::shared_ptr<const EPTio::HierarchyIndex> idx) { ept_index = std::move(idx); }
+
 private:
   Header* header;
   EPTio* eptio;
   bool streaming;
+  std::shared_ptr<const EPTio::HierarchyIndex> ept_index;
+  bool chunk_strict_clip = false;
+  double catalog_xmax = 0;
+  double catalog_ymax = 0;
 };
 
 #endif

--- a/src/LASRstages/readlas.cpp
+++ b/src/LASRstages/readlas.cpp
@@ -70,7 +70,7 @@ bool LASRlasreader::process(Point*& point)
   {
     if (lasio->read_point(point))
     {
-      if (point->inside_buffer(xmin, ymin, ymax, ymax, circular))
+      if (point->inside_buffer(xmin, ymin, xmax, ymax, circular))
         point->set_buffered();
     }
     else

--- a/src/LASRstages/readpcd.cpp
+++ b/src/LASRstages/readpcd.cpp
@@ -79,7 +79,7 @@ bool LASRpcdreader::process(Point*& point)
   {
     if (pcdio->read_point(point))
     {
-      if (point->inside_buffer(xmin, ymin, ymax, ymax, circular))
+      if (point->inside_buffer(xmin, ymin, xmax, ymax, circular))
         point->set_buffered();
     }
     else

--- a/src/LASRstages/summary.cpp
+++ b/src/LASRstages/summary.cpp
@@ -33,7 +33,7 @@ bool LASRsummary::process(Point*& p)
 {
   if (p->get_deleted()) return true;
   if (pointfilter.filter(p)) return true;
-  if (p->inside_buffer(xmin, ymin, xmax, ymax, circular)) return true; // avoid counting buffer points
+  if (p->get_buffered() || p->inside_buffer(xmin, ymin, xmax, ymax, circular)) return true; // avoid counting buffer points
 
   npoints++;
   npoints_per_return[get_returnnumber(p)]++;

--- a/src/LASRstages/writelas.cpp
+++ b/src/LASRstages/writelas.cpp
@@ -94,7 +94,7 @@ bool LASRlaswriter::process(Point*& p)
   }
 
   //  If the point in not in the buffer we can write it
-  if (keep_buffer || !p->inside_buffer(xmin, ymin, xmax, ymax, circular))
+  if (keep_buffer || (!p->get_buffered() && !p->inside_buffer(xmin, ymin, xmax, ymax, circular)))
   {
     if (!pointfilter.filter(p))
     {

--- a/src/Rbinding.cpp
+++ b/src/Rbinding.cpp
@@ -613,6 +613,26 @@ bool cpp_writelas_buffer_decide(bool buffered,
   return !p.get_buffered() && !p.inside_buffer(xmin, ymin, xmax, ymax, circular);
 }
 
+// Directly exercises FileCollection::ept_pick_depth_for_aois so the
+// depth-selection logic can be tested without standing up an EPT
+// endpoint (the local fixture has max_tile_depth=1, which masks the
+// behavior under test). Returns the picked depth.
+int cpp_ept_pick_depth(double cube_xmin, double cube_ymin, double cube_size,
+                       int max_tile_depth, int target_partitions,
+                       Rcpp::List rects)
+{
+  std::vector<std::array<double, 4>> aois;
+  aois.reserve(rects.size());
+  for (int i = 0; i < rects.size(); ++i) {
+    Rcpp::NumericVector r = rects[i];
+    if (r.size() != 4) Rcpp::stop("Each rect must be c(xmin, ymin, xmax, ymax)");
+    aois.push_back({r[0], r[1], r[2], r[3]});
+  }
+  return FileCollection::ept_pick_depth_for_aois(
+      cube_xmin, cube_ymin, cube_size,
+      max_tile_depth, target_partitions, aois);
+}
+
 // Replays the buffer classification inside callback.cpp's drop_buffer
 // decision (around line 350). Returns true if the point is classified
 // as buffer (i.e., would be skipped when drop_buffer=true).
@@ -649,6 +669,7 @@ RCPP_MODULE(tests)
   function("cpp_summary_buffer_decide", &cpp_summary_buffer_decide, "Summary buffer decision");
   function("cpp_writelas_buffer_decide", &cpp_writelas_buffer_decide, "Writelas buffer decision");
   function("cpp_callback_buffer_decide", &cpp_callback_buffer_decide, "Callback buffer decision");
+  function("cpp_ept_pick_depth", &cpp_ept_pick_depth, "EPT partition depth selection");
 }
 
 

--- a/src/Rbinding.cpp
+++ b/src/Rbinding.cpp
@@ -31,6 +31,11 @@ namespace Rcpp
 
 #include <Rcpp.h>
 
+#include "Chunk.h"
+#include "FileCollection.h"
+#include "EPTio.h"
+#include "ept_partition_gate.h"
+
 using namespace Rcpp;
 
 // Generic tools that could be used by any API
@@ -482,10 +487,53 @@ SEXP cpp_test2(std::vector<std::string> on)
   return execute(file);
 }
 
+SEXP cpp_ept_partition_inspect(std::string endpoint, int target_partitions)
+{
+  FileCollection fc;
+  if (!fc.read({endpoint})) Rcpp::stop(last_error);
+  if (!fc.partition_ept(target_partitions)) Rcpp::stop(last_error);
+
+  int n = fc.get_number_chunks();
+  Rcpp::NumericMatrix bb(n, 4);
+  Rcpp::LogicalVector strict(n);
+  for (int i = 0; i < n; ++i) {
+    Chunk c;
+    fc.get_chunk(i, c);
+    bb(i, 0) = c.xmin; bb(i, 1) = c.ymin;
+    bb(i, 2) = c.xmax; bb(i, 3) = c.ymax;
+    strict[i] = c.strict_clip;
+  }
+  auto idx = fc.get_ept_index();
+  Rcpp::NumericVector cb(4);
+  cb[0] = idx->conf_bounds[0]; cb[1] = idx->conf_bounds[1];
+  cb[2] = idx->conf_bounds[3]; cb[3] = idx->conf_bounds[4];
+  return Rcpp::List::create(
+    Rcpp::_["nchunks"] = n,
+    Rcpp::_["bbox"] = bb,
+    Rcpp::_["strict_clip"] = strict,
+    Rcpp::_["conf_bounds"] = cb,
+    Rcpp::_["tiles_built"] = idx->tiles_built);
+}
+
+bool cpp_ept_should_auto_partition(std::string format_signature,
+                                   bool is_parallelizable,
+                                   bool use_rcapi,
+                                   int ncpu_outer_loop)
+{
+  PathType format = UNKNOWNFILE;
+  if (format_signature == "EPTF") format = EPTFILE;
+  else if (format_signature == "LASF") format = LASFILE;
+  else if (format_signature == "PCDF") format = PCDFILE;
+  return api_internal::should_auto_partition_ept(
+      format, is_parallelizable, use_rcapi, ncpu_outer_loop);
+}
+
 RCPP_MODULE(tests)
 {
   function("cpp_test1", &cpp_test1, "Test 1");
   function("cpp_test2", &cpp_test2, "Test 2");
+  function("cpp_ept_partition_inspect", &cpp_ept_partition_inspect, "Inspect EPT partition");
+  function("cpp_ept_should_auto_partition", &cpp_ept_should_auto_partition, "EPT auto-partition gate");
 }
 
 

--- a/src/Rbinding.cpp
+++ b/src/Rbinding.cpp
@@ -488,30 +488,52 @@ SEXP cpp_test2(std::vector<std::string> on)
   return execute(file);
 }
 
-SEXP cpp_ept_partition_inspect(std::string endpoint, int target_partitions)
+SEXP cpp_ept_partition_inspect(std::string endpoint, int target_partitions,
+                               Rcpp::List rects = Rcpp::List(),
+                               Rcpp::List circles = Rcpp::List())
 {
   FileCollection fc;
   if (!fc.read({endpoint})) Rcpp::stop(last_error);
+
+  for (int i = 0; i < rects.size(); ++i) {
+    Rcpp::NumericVector r = rects[i];
+    if (r.size() != 4) Rcpp::stop("Each rect must be c(xmin, ymin, xmax, ymax)");
+    fc.add_query(r[0], r[1], r[2], r[3]);
+  }
+  for (int i = 0; i < circles.size(); ++i) {
+    Rcpp::NumericVector c = circles[i];
+    if (c.size() != 3) Rcpp::stop("Each circle must be c(xcenter, ycenter, radius)");
+    fc.add_query(c[0], c[1], c[2]);
+  }
+
   if (!fc.partition_ept(target_partitions)) Rcpp::stop(last_error);
 
   int n = fc.get_number_chunks();
   Rcpp::NumericMatrix bb(n, 4);
   Rcpp::LogicalVector strict(n);
+  Rcpp::CharacterVector shape_type(n);
+  Rcpp::NumericVector owner_xmax(n), owner_ymax(n);
   for (int i = 0; i < n; ++i) {
     Chunk c;
     fc.get_chunk(i, c);
     bb(i, 0) = c.xmin; bb(i, 1) = c.ymin;
     bb(i, 2) = c.xmax; bb(i, 3) = c.ymax;
     strict[i] = c.strict_clip;
+    shape_type[i] = (c.shape == ShapeType::CIRCLE) ? "circle" : "rect";
+    owner_xmax[i] = c.catalog_xmax;
+    owner_ymax[i] = c.catalog_ymax;
   }
   auto idx = fc.get_ept_index();
   Rcpp::NumericVector cb(4);
   cb[0] = idx->conf_bounds[0]; cb[1] = idx->conf_bounds[1];
   cb[2] = idx->conf_bounds[3]; cb[3] = idx->conf_bounds[4];
   return Rcpp::List::create(
-    Rcpp::_["nchunks"] = n,
-    Rcpp::_["bbox"] = bb,
+    Rcpp::_["nchunks"]     = n,
+    Rcpp::_["bbox"]        = bb,
     Rcpp::_["strict_clip"] = strict,
+    Rcpp::_["shape_type"]  = shape_type,
+    Rcpp::_["owner_xmax"]  = owner_xmax,
+    Rcpp::_["owner_ymax"]  = owner_ymax,
     Rcpp::_["conf_bounds"] = cb,
     Rcpp::_["tiles_built"] = idx->tiles_built);
 }
@@ -591,7 +613,12 @@ RCPP_MODULE(tests)
 {
   function("cpp_test1", &cpp_test1, "Test 1");
   function("cpp_test2", &cpp_test2, "Test 2");
-  function("cpp_ept_partition_inspect", &cpp_ept_partition_inspect, "Inspect EPT partition");
+  function("cpp_ept_partition_inspect", &cpp_ept_partition_inspect,
+           Rcpp::List::create(Rcpp::_["endpoint"],
+                              Rcpp::_["target_partitions"],
+                              Rcpp::_["rects"]   = Rcpp::List(),
+                              Rcpp::_["circles"] = Rcpp::List()),
+           "Inspect EPT partition");
   function("cpp_ept_should_auto_partition", &cpp_ept_should_auto_partition, "EPT auto-partition gate");
   function("cpp_strict_clip_decide", &cpp_strict_clip_decide, "Strict-clip decision predicate");
   function("cpp_summary_buffer_decide", &cpp_summary_buffer_decide, "Summary buffer decision");

--- a/src/Rbinding.cpp
+++ b/src/Rbinding.cpp
@@ -546,6 +546,47 @@ int cpp_strict_clip_decide(double px, double py,
   return -1;
 }
 
+// Replays summary.cpp's filter decision against a synthetic Point.
+// Returns true if the point would be DROPPED from the summary
+// (i.e., classified as buffer).
+bool cpp_summary_buffer_decide(bool buffered,
+                               double px, double py,
+                               double xmin, double ymin,
+                               double xmax, double ymax,
+                               bool circular)
+{
+  AttributeSchema schema;
+  schema.add_attribute("flags", AttributeType::UINT8, 1, 0, "Internal 8-bit mask reserved for lasR core engine");
+  schema.add_attribute("X", AttributeType::INT32, 1.0, 0.0, "X coordinate");
+  schema.add_attribute("Y", AttributeType::INT32, 1.0, 0.0, "Y coordinate");
+  Point p(&schema);
+  p.set_x(px);
+  p.set_y(py);
+  p.set_buffered(buffered);
+  // Production check from summary.cpp:36 after the contract fix:
+  return p.get_buffered() || p.inside_buffer(xmin, ymin, xmax, ymax, circular);
+}
+
+// Replays writelas.cpp's keep/drop decision (with keep_buffer=false).
+// Returns true if the point would be WRITTEN (kept), false if dropped.
+bool cpp_writelas_buffer_decide(bool buffered,
+                                double px, double py,
+                                double xmin, double ymin,
+                                double xmax, double ymax,
+                                bool circular)
+{
+  AttributeSchema schema;
+  schema.add_attribute("flags", AttributeType::UINT8, 1, 0, "Internal 8-bit mask reserved for lasR core engine");
+  schema.add_attribute("X", AttributeType::INT32, 1.0, 0.0, "X coordinate");
+  schema.add_attribute("Y", AttributeType::INT32, 1.0, 0.0, "Y coordinate");
+  Point p(&schema);
+  p.set_x(px);
+  p.set_y(py);
+  p.set_buffered(buffered);
+  // Production check from writelas.cpp:97 after the contract fix:
+  return !p.get_buffered() && !p.inside_buffer(xmin, ymin, xmax, ymax, circular);
+}
+
 RCPP_MODULE(tests)
 {
   function("cpp_test1", &cpp_test1, "Test 1");
@@ -553,6 +594,8 @@ RCPP_MODULE(tests)
   function("cpp_ept_partition_inspect", &cpp_ept_partition_inspect, "Inspect EPT partition");
   function("cpp_ept_should_auto_partition", &cpp_ept_should_auto_partition, "EPT auto-partition gate");
   function("cpp_strict_clip_decide", &cpp_strict_clip_decide, "Strict-clip decision predicate");
+  function("cpp_summary_buffer_decide", &cpp_summary_buffer_decide, "Summary buffer decision");
+  function("cpp_writelas_buffer_decide", &cpp_writelas_buffer_decide, "Writelas buffer decision");
 }
 
 

--- a/src/Rbinding.cpp
+++ b/src/Rbinding.cpp
@@ -519,7 +519,11 @@ SEXP cpp_ept_partition_inspect(std::string endpoint, int target_partitions,
     bb(i, 0) = c.xmin; bb(i, 1) = c.ymin;
     bb(i, 2) = c.xmax; bb(i, 3) = c.ymax;
     strict[i] = c.strict_clip;
-    shape_type[i] = (c.shape == ShapeType::CIRCLE) ? "circle" : "rect";
+    switch (fc.get_query_type(i)) {
+      case ShapeType::CIRCLE:    shape_type[i] = "circle";  break;
+      case ShapeType::RECTANGLE: shape_type[i] = "rect";    break;
+      default:                   shape_type[i] = "unknown"; break;
+    }
     owner_xmax[i] = c.catalog_xmax;
     owner_ymax[i] = c.catalog_ymax;
   }

--- a/src/Rbinding.cpp
+++ b/src/Rbinding.cpp
@@ -613,6 +613,27 @@ bool cpp_writelas_buffer_decide(bool buffered,
   return !p.get_buffered() && !p.inside_buffer(xmin, ymin, xmax, ymax, circular);
 }
 
+// Replays the buffer classification inside callback.cpp's drop_buffer
+// decision (around line 350). Returns true if the point is classified
+// as buffer (i.e., would be skipped when drop_buffer=true).
+bool cpp_callback_buffer_decide(bool buffered,
+                                double px, double py,
+                                double xmin, double ymin,
+                                double xmax, double ymax,
+                                bool circular)
+{
+  AttributeSchema schema;
+  schema.add_attribute("flags", AttributeType::UINT8, 1, 0, "Internal 8-bit mask reserved for lasR core engine");
+  schema.add_attribute("X", AttributeType::INT32, 1.0, 0.0, "X coordinate");
+  schema.add_attribute("Y", AttributeType::INT32, 1.0, 0.0, "Y coordinate");
+  Point p(&schema);
+  p.set_x(px);
+  p.set_y(py);
+  p.set_buffered(buffered);
+  // Mirrors callback.cpp after the ownership contract fix.
+  return p.get_buffered() || p.inside_buffer(xmin, ymin, xmax, ymax, circular);
+}
+
 RCPP_MODULE(tests)
 {
   function("cpp_test1", &cpp_test1, "Test 1");
@@ -627,6 +648,7 @@ RCPP_MODULE(tests)
   function("cpp_strict_clip_decide", &cpp_strict_clip_decide, "Strict-clip decision predicate");
   function("cpp_summary_buffer_decide", &cpp_summary_buffer_decide, "Summary buffer decision");
   function("cpp_writelas_buffer_decide", &cpp_writelas_buffer_decide, "Writelas buffer decision");
+  function("cpp_callback_buffer_decide", &cpp_callback_buffer_decide, "Callback buffer decision");
 }
 
 

--- a/src/Rbinding.cpp
+++ b/src/Rbinding.cpp
@@ -35,6 +35,7 @@ namespace Rcpp
 #include "FileCollection.h"
 #include "EPTio.h"
 #include "ept_partition_gate.h"
+#include "readept.h"
 
 using namespace Rcpp;
 
@@ -528,12 +529,30 @@ bool cpp_ept_should_auto_partition(std::string format_signature,
       format, is_parallelizable, use_rcapi, ncpu_outer_loop);
 }
 
+// Returns 0=DROP, 1=CORE, 2=BUFFERED.
+int cpp_strict_clip_decide(double px, double py,
+                           double xmin, double xmax,
+                           double ymin, double ymax,
+                           double buffer,
+                           double catalog_xmax, double catalog_ymax)
+{
+  auto d = LASReptreader::strict_clip_decide(
+      px, py, xmin, xmax, ymin, ymax, buffer, catalog_xmax, catalog_ymax);
+  switch (d) {
+    case LASReptreader::DROP:     return 0;
+    case LASReptreader::CORE:     return 1;
+    case LASReptreader::BUFFERED: return 2;
+  }
+  return -1;
+}
+
 RCPP_MODULE(tests)
 {
   function("cpp_test1", &cpp_test1, "Test 1");
   function("cpp_test2", &cpp_test2, "Test 2");
   function("cpp_ept_partition_inspect", &cpp_ept_partition_inspect, "Inspect EPT partition");
   function("cpp_ept_should_auto_partition", &cpp_ept_should_auto_partition, "EPT auto-partition gate");
+  function("cpp_strict_clip_decide", &cpp_strict_clip_decide, "Strict-clip decision predicate");
 }
 
 

--- a/src/vendor/LASlib/lasreader_las.cpp
+++ b/src/vendor/LASlib/lasreader_las.cpp
@@ -73,8 +73,12 @@ BOOL LASreaderLAS::open(const char* file_name, I32 io_buffer_size, BOOL peek_onl
       vsi_path = file_name;
     }
 
-    // Size warning for non-COPC files
-    if (strstr(file_name, ".copc.") == NULL)
+    // Size warning for non-COPC files. The VSIStatL does a HEAD request,
+    // which is expensive when tens or hundreds of small remote files are
+    // opened in sequence (e.g. EPT tile fetches). lasR sets
+    // LASR_SKIP_REMOTE_SIZE_WARN=1 during EPT reads to suppress it.
+    if (strstr(file_name, ".copc.") == NULL &&
+        !std::getenv("LASR_SKIP_REMOTE_SIZE_WARN"))
     {
       VSIStatBufL stat_buf;
       if (VSIStatL(vsi_path.c_str(), &stat_buf) == 0)

--- a/src/vendor/LASlib/lasreader_las.cpp
+++ b/src/vendor/LASlib/lasreader_las.cpp
@@ -73,12 +73,16 @@ BOOL LASreaderLAS::open(const char* file_name, I32 io_buffer_size, BOOL peek_onl
       vsi_path = file_name;
     }
 
-    // Size warning for non-COPC files. The VSIStatL does a HEAD request,
-    // which is expensive when tens or hundreds of small remote files are
-    // opened in sequence (e.g. EPT tile fetches). lasR sets
-    // LASR_SKIP_REMOTE_SIZE_WARN=1 during EPT reads to suppress it.
+    // Size warning for non-COPC files. The VSIStatL is a HEAD request,
+    // which is expensive when tens or hundreds of small remote files
+    // are opened in sequence (e.g. EPT tile fetches under `ept-data/`).
+    // EPT tiles are bounded by the span (typically <10 MB), so the
+    // >500 MB warning would never fire anyway — skip the HEAD entirely
+    // for any path matching the EPT tile layout. This scoping avoids
+    // a process-wide env-var that would also silence the warning for
+    // unrelated big remote LAS reads in the same R session.
     if (strstr(file_name, ".copc.") == NULL &&
-        !std::getenv("LASR_SKIP_REMOTE_SIZE_WARN"))
+        strstr(file_name, "/ept-data/") == NULL)
     {
       VSIStatBufL stat_buf;
       if (VSIStatL(vsi_path.c_str(), &stat_buf) == 0)

--- a/src/vendor/LASzip/mydefs.cpp
+++ b/src/vendor/LASzip/mydefs.cpp
@@ -72,7 +72,13 @@ bool is_remote_path(const char* path)
       strncmp(sub, "az/", 3) == 0    ||
       strncmp(sub, "adls/", 5) == 0  ||
       strncmp(sub, "oss/", 4) == 0   ||
-      strncmp(sub, "swift/", 6) == 0;
+      strncmp(sub, "swift/", 6) == 0 ||
+      // /vsimem/ is GDAL's in-memory filesystem. Not literally "remote",
+      // but it must be opened via VSIFOpenL (not regular fopen), so route
+      // it through the same branch as the cloud schemes. lasR's EPT reader
+      // uses /vsimem/ to stage prefetched tile bytes so the consumer reads
+      // from RAM (see LASRreaders/EPTio.cpp::open_tile_sync).
+      strncmp(sub, "mem/", 4) == 0;
   }
 
   return false;

--- a/tests/testthat/test-ept.R
+++ b/tests/testthat/test-ept.R
@@ -469,3 +469,35 @@ test_that("EPT partition: mixed rect + circle splits the rect, passes circle thr
   expect_gt(sum(rects), 1L)
   expect_equal(sum(circles), 1L)
 })
+
+test_that("EPT partition: rect AOI parallel read equals serial AOI read exactly", {
+  skip_if_not(has_omp_support())
+  ept <- system.file("extdata", "ept-test-multi", "ept.json", package = "lasR")
+  q <- reader_rectangles(273360, 5274360, 273640, 5274640)
+  par <- exec(q + summarise(), on = ept, ncores = concurrent_files(4))
+  ser <- exec(q + summarise(), on = ept, ncores = sequential())
+  expect_equal(par$npoints,     ser$npoints)
+  expect_equal(par$z_histogram, ser$z_histogram)
+})
+
+test_that("EPT partition: rect AOI parallel write equals serial AOI summarise exactly", {
+  skip_if_not(has_omp_support())
+  ept <- system.file("extdata", "ept-test-multi", "ept.json", package = "lasR")
+  out_par <- file.path(tempdir(), "ept-aoi-par")
+  dir.create(out_par, showWarnings = FALSE)
+  on.exit(unlink(out_par, recursive = TRUE), add = TRUE)
+
+  q <- reader_rectangles(273360, 5274360, 273640, 5274640)
+  exec(q + write_las(file.path(out_par, "*.las")), on = ept,
+       ncores = concurrent_files(4))
+  ser_npoints <- exec(q + summarise(), on = ept, ncores = sequential())$npoints
+
+  # The parallel write_las with the glob template uses keep_buffer=FALSE
+  # semantics (per-chunk files contain only their core, not buffer ring).
+  # Sum the per-chunk written totals; they must equal the canonical
+  # serial summarise count — no duplicates, no losses across the
+  # strict-clipped sub-queries.
+  par_total <- sum(sapply(list.files(out_par, full.names = TRUE),
+    function(f) exec(reader() + summarise(), on = f)$npoints))
+  expect_equal(par_total, ser_npoints)
+})

--- a/tests/testthat/test-ept.R
+++ b/tests/testthat/test-ept.R
@@ -68,3 +68,130 @@ test_that("Multiple EPT endpoints produce an error",
   ept <- system.file("extdata", "ept-test-multi", "ept.json", package = "lasR")
   expect_error(exec(reader() + summarise(), on = c(ept, ept)), "single EPT")
 })
+
+ept <- system.file("extdata", "ept-test-multi", "ept.json", package = "lasR")
+
+test_that("EPT parallel full read equals serial full read",
+{
+  skip_if_not(has_omp_support())
+  par <- exec(reader() + summarise(), on = ept,
+              ncores = concurrent_files(4))
+  ser <- exec(reader() + summarise(), on = ept,
+              ncores = sequential())
+  expect_equal(par$npoints, ser$npoints)
+  expect_equal(par$z_histogram, ser$z_histogram)
+})
+
+test_that("EPT parallel spatial query equals serial spatial query",
+{
+  skip_if_not(has_omp_support())
+  q <- reader_rectangles(273360, 5274360, 273490, 5274490)
+  par <- exec(q + summarise(), on = ept, ncores = concurrent_files(4))
+  ser <- exec(q + summarise(), on = ept, ncores = sequential())
+  expect_equal(par$npoints, ser$npoints)
+  expect_equal(par$z_histogram, ser$z_histogram)
+})
+
+test_that("EPT partition count scales and all partitions are strict",
+{
+  skip_if_not(has_omp_support())
+  insp <- lasR:::.APITEST$cpp_ept_partition_inspect(ept, 16)
+  expect_gt(insp$nchunks, 1)
+  expect_true(all(insp$strict_clip))
+  expect_true(insp$tiles_built)
+})
+
+test_that("EPT partitions stay inside conforming bounds",
+{
+  insp <- lasR:::.APITEST$cpp_ept_partition_inspect(ept, 16)
+  cb <- insp$conf_bounds
+  expect_true(all(insp$bbox[,1] >= cb[1] - 1e-9))
+  expect_true(all(insp$bbox[,2] >= cb[2] - 1e-9))
+  expect_true(all(insp$bbox[,3] <= cb[3] + 1e-9))
+  expect_true(all(insp$bbox[,4] <= cb[4] + 1e-9))
+})
+
+test_that("EPT strict-clip core ownership is unique (no duplicates, no losses)",
+{
+  skip_if_not(has_omp_support())
+  out_dir <- file.path(tempdir(), "ept-strict-clip")
+  dir.create(out_dir, showWarnings = FALSE)
+  on.exit(unlink(out_dir, recursive = TRUE), add = TRUE)
+  ofiles <- file.path(out_dir, "*.las")
+
+  exec(reader() + write_las(ofiles), on = ept, ncores = concurrent_files(4))
+  written <- list.files(out_dir, pattern = "\\.las$", full.names = TRUE)
+  expect_gt(length(written), 1)
+
+  total_par <- sum(sapply(written, function(f)
+    exec(reader() + summarise(), on = f)$npoints))
+  total_ser <- exec(reader() + summarise(), on = ept,
+                    ncores = sequential())$npoints
+  expect_equal(total_par, total_ser)
+})
+
+test_that("EPT explicit chunk override produces correct results",
+{
+  ans_chunked <- exec(reader() + summarise(), on = ept, chunk = 100,
+                      ncores = sequential())
+  ans_seq <- exec(reader() + summarise(), on = ept, ncores = sequential())
+  # Explicit `chunk` uses non-strict clipping (overlap-based), so a few
+  # boundary points may be counted in more than one chunk. The override
+  # must run successfully and yield a count within a small tolerance of
+  # the serial total (the auto-partitioned path uses strict clipping and
+  # is exact; that case is covered by other tests).
+  expect_gte(ans_chunked$npoints, ans_seq$npoints)
+  expect_lt(ans_chunked$npoints, ans_seq$npoints * 1.01)
+})
+
+test_that("EPT env-var validation falls back gracefully",
+{
+  skip_if_not(has_omp_support())
+  # The C++ layer routes warnings through REprintf rather than R's
+  # warning() mechanism (project-wide convention in src/LASRcore/print.cpp),
+  # so we capture stderr instead of relying on expect_warning().
+  on.exit(Sys.unsetenv("LASR_EPT_PARTITIONS"), add = TRUE)
+  ser_npoints <- exec(reader() + summarise(), on = ept,
+                      ncores = sequential())$npoints
+  for (val in c("0", "-1", "foo", "99999")) {
+    Sys.setenv(LASR_EPT_PARTITIONS = val)
+    msg <- capture.output(
+      ans <- exec(reader() + summarise(), on = ept,
+                  ncores = concurrent_files(4)),
+      type = "message")
+    expect_match(paste(msg, collapse = "\n"),
+                 "LASR_EPT_PARTITIONS")
+    expect_equal(ans$npoints, ser_npoints)
+  }
+})
+
+test_that("EPT auto-partition gate matches all downgrade scenarios",
+{
+  gate <- lasR:::.APITEST$cpp_ept_should_auto_partition
+
+  # Positive: EPT + parallelizable + no R callback + outer > 1
+  expect_true(gate("EPTF", TRUE, FALSE, 4))
+
+  # Downgrade A: pipeline not parallelizable
+  expect_false(gate("EPTF", FALSE, FALSE, 4))
+
+  # Downgrade B: pipeline injects R code (use_rcapi)
+  expect_false(gate("EPTF", TRUE, TRUE, 4))
+
+  # Downgrade C: only one outer thread requested
+  expect_false(gate("EPTF", TRUE, FALSE, 1))
+
+  # Format guard: non-EPT sources are not auto-partitioned
+  expect_false(gate("LASF", TRUE, FALSE, 4))
+  expect_false(gate("PCDF", TRUE, FALSE, 4))
+})
+
+test_that("EPT non-parallelizable pipeline still produces correct results",
+{
+  skip_if_not(has_omp_support())
+  par <- exec(reader() + callback(function(data) data, expose = "*"),
+              on = ept, ncores = concurrent_files(4))
+  ser <- exec(reader() + callback(function(data) data, expose = "*"),
+              on = ept, ncores = sequential())
+  expect_equal(length(par), length(ser))
+})

--- a/tests/testthat/test-ept.R
+++ b/tests/testthat/test-ept.R
@@ -355,3 +355,39 @@ test_that("EPT partition: rect AOI outside conf_bounds passes through", {
   # the query — passthrough leaves the Shape* untouched, but the reported
   # chunk bbox reflects the no-file-match placeholder, not the original rect.
 })
+
+# ----- AOI partition: hierarchy walk failure (spec rev 5 test 9) -----
+
+test_that("EPT partition: malformed sub-hierarchy with AOI → passthrough + warning", {
+  src <- system.file("extdata", "ept-test-multi", package = "lasR")
+  dst <- file.path(tempdir(), "ept-broken-subhier")
+  unlink(dst, recursive = TRUE)
+  dir.create(dst, showWarnings = FALSE)
+  file.copy(file.path(src, "ept.json"), dst)
+  dir.create(file.path(dst, "ept-data"), showWarnings = FALSE)
+  dir.create(file.path(dst, "ept-hierarchy"), showWarnings = FALSE)
+  file.copy(list.files(file.path(src, "ept-data"), full.names = TRUE),
+            file.path(dst, "ept-data"))
+  file.copy(list.files(file.path(src, "ept-hierarchy"), full.names = TRUE),
+            file.path(dst, "ept-hierarchy"))
+
+  # Find a non-root sub-hierarchy page referenced from the root via -1.
+  root <- jsonlite::fromJSON(file.path(dst, "ept-hierarchy", "0-0-0-0.json"))
+  sub_keys <- names(root)[unlist(root) == -1]
+  skip_if(length(sub_keys) == 0,
+          "test fixture root has no -1 sub-page references")
+  broken_key <- sub_keys[1]
+  writeLines("{ not valid json",
+             file.path(dst, "ept-hierarchy", paste0(broken_key, ".json")))
+
+  endpoint <- file.path(dst, "ept.json")
+  msg <- capture.output(
+    insp <- lasR:::.APITEST$cpp_ept_partition_inspect(
+      endpoint, 16, list(c(273400, 5274400, 273600, 5274600))),
+    type = "message")
+  expect_equal(insp$nchunks, 1L)
+  expect_equal(as.character(insp$shape_type), "rect")
+  expect_equal(insp$bbox[1, ], c(273400, 5274400, 273600, 5274600))
+  expect_match(paste(msg, collapse = "\n"),
+               "AOI partitioning skipped|hierarchy")
+})

--- a/tests/testthat/test-ept.R
+++ b/tests/testthat/test-ept.R
@@ -335,3 +335,23 @@ test_that("writelas honors get_buffered() flag (boundary semantics)", {
   expect_false(lasR:::.APITEST$cpp_writelas_buffer_decide(
     TRUE,  5, 5, 0, 0, 10, 10, TRUE))
 })
+
+# ----- AOI partition: passthrough cases (spec rev 5 tests 5, 6) -----
+
+test_that("EPT partition: circle AOI passes through", {
+  insp <- lasR:::.APITEST$cpp_ept_partition_inspect(
+    ept, 16, list(),
+    list(c(273500, 5274500, 50)))  # circle inside conf_bounds
+  expect_equal(insp$nchunks, 1L)
+  expect_equal(as.character(insp$shape_type), "circle")
+})
+
+test_that("EPT partition: rect AOI outside conf_bounds passes through", {
+  insp <- lasR:::.APITEST$cpp_ept_partition_inspect(
+    ept, 16, list(c(1, 2, 3, 4)))  # nowhere near the data
+  expect_equal(insp$nchunks, 1L)
+  expect_equal(as.character(insp$shape_type), "rect")
+  # Note: get_chunk_with_query zeros the chunk bbox when no files overlap
+  # the query — passthrough leaves the Shape* untouched, but the reported
+  # chunk bbox reflects the no-file-match placeholder, not the original rect.
+})

--- a/tests/testthat/test-ept.R
+++ b/tests/testthat/test-ept.R
@@ -195,3 +195,76 @@ test_that("EPT non-parallelizable pipeline still produces correct results",
               on = ept, ncores = sequential())
   expect_equal(length(par), length(ser))
 })
+
+# ----- Strict-clip boundary policy (spec §5 test 5) -----
+#
+# Direct unit tests of the per-point ownership predicate. cpp_strict_clip_decide
+# returns 0=DROP, 1=CORE, 2=BUFFERED for a single (px, py) given the chunk
+# extent, buffer, and catalog global max. This catches floating-point boundary
+# bugs that integration tests can't easily reach because real-world point data
+# rarely lands exactly on a partition midline.
+
+DROP <- 0L; CORE <- 1L; BUFFERED <- 2L
+decide <- function(px, py, xmin, xmax, ymin, ymax,
+                   buffer = 0, catalog_xmax = xmax, catalog_ymax = ymax)
+{
+  lasR:::.APITEST$cpp_strict_clip_decide(
+    px, py, xmin, xmax, ymin, ymax, buffer,
+    catalog_xmax, catalog_ymax)
+}
+
+test_that("strict-clip: core, buffer-ring, and drop regions",
+{
+  # Chunk [0, 10] x [0, 10] with buffer = 2, NOT at global max.
+  # Catalog extends to 100, 100 so xmax/ymax carve-out won't fire.
+  expect_equal(decide(5,    5,   0, 10, 0, 10, 2, 100, 100), CORE)
+  expect_equal(decide(11,   5,   0, 10, 0, 10, 2, 100, 100), BUFFERED)
+  expect_equal(decide(11.9, 5,   0, 10, 0, 10, 2, 100, 100), BUFFERED)
+  expect_equal(decide(12.1, 5,   0, 10, 0, 10, 2, 100, 100), DROP)
+  expect_equal(decide(-1,   5,   0, 10, 0, 10, 2, 100, 100), BUFFERED)
+  expect_equal(decide(-2.1, 5,   0, 10, 0, 10, 2, 100, 100), DROP)
+})
+
+test_that("strict-clip: half-open ownership at the right/top edge",
+{
+  # px == xmax but xmax != catalog_xmax → not the rightmost cell → BUFFERED.
+  expect_equal(decide(10, 5, 0, 10, 0, 10, 2, 100, 100), BUFFERED)
+  expect_equal(decide(5, 10, 0, 10, 0, 10, 2, 100, 100), BUFFERED)
+})
+
+test_that("strict-clip: global-max-inclusive carve-out keeps rightmost edge",
+{
+  # px == xmax AND xmax == catalog_xmax → the rightmost cell owns its outer edge.
+  expect_equal(decide(10, 5, 0, 10, 0, 10, 2, 10, 100), CORE)
+  expect_equal(decide(5, 10, 0, 10, 0, 10, 2, 100, 10), CORE)
+  expect_equal(decide(10, 10, 0, 10, 0, 10, 2, 10, 10), CORE)
+})
+
+test_that("strict-clip: half-open at xmin includes the boundary",
+{
+  # px == xmin → owns_x = (px >= xmin) && (px < xmax) → CORE.
+  # The left/bottom edge is closed; the right/top edge is open (unless global max).
+  expect_equal(decide(0, 5, 0, 10, 0, 10, 2, 100, 100), CORE)
+  expect_equal(decide(5, 0, 0, 10, 0, 10, 2, 100, 100), CORE)
+})
+
+test_that("strict-clip: shared midline owned by exactly one of two adjacent cells",
+{
+  # Cell A:  [0, 5)  x [0, 10]      (its xmax = 5, NOT at global max)
+  # Cell B:  [5, 10] x [0, 10]      (its xmin = 5)
+  # Catalog xmax = 10 → only Cell B is "rightmost" in x.
+  # A point at exactly x = 5 must be CORE in Cell B and BUFFERED in Cell A.
+  expect_equal(decide(5, 5,   0, 5,  0, 10, 2, 10, 10), BUFFERED)
+  expect_equal(decide(5, 5,   5, 10, 0, 10, 2, 10, 10), CORE)
+})
+
+test_that("strict-clip: zero buffer collapses buffer ring to nothing",
+{
+  # With buffer = 0, the buffered extent equals the core extent. Any point
+  # strictly outside [xmin, xmax]×[ymin, ymax] is DROP, never BUFFERED.
+  expect_equal(decide(5,    5,   0, 10, 0, 10, 0, 100, 100), CORE)
+  expect_equal(decide(10.1, 5,   0, 10, 0, 10, 0, 100, 100), DROP)
+  expect_equal(decide(5,    -0.1, 0, 10, 0, 10, 0, 100, 100), DROP)
+  # px == xmax (not global) → still inside buffered extent → BUFFERED.
+  expect_equal(decide(10, 5, 0, 10, 0, 10, 0, 100, 100), BUFFERED)
+})

--- a/tests/testthat/test-ept.R
+++ b/tests/testthat/test-ept.R
@@ -499,6 +499,30 @@ test_that("EPT partition: rect AOI parallel read equals serial AOI read exactly"
   expect_equal(par$z_histogram, ser$z_histogram)
 })
 
+test_that("EPT partition: long-thin rect AOI produces multi-cell partition", {
+  # The previous depth formula used aoi_area/cube_area, which undercounted
+  # long-thin AOIs: a strip ~280 m × 5 m has tiny area but spans the cube
+  # in x. The cell-count iteration picks a depth where the AOI covers
+  # multiple cells regardless of how degenerate one dimension is.
+  ept <- system.file("extdata", "ept-test-multi", "ept.json", package = "lasR")
+  cb <- lasR:::.APITEST$cpp_ept_partition_inspect(ept, 1)$conf_bounds
+  ymid <- (cb[2] + cb[4]) / 2
+  thin <- c(cb[1] + 1, ymid - 2.5, cb[3] - 1, ymid + 2.5)
+  insp <- lasR:::.APITEST$cpp_ept_partition_inspect(ept, 16, list(thin))
+  expect_gt(insp$nchunks, 1L)
+  expect_true(all(insp$strict_clip))
+})
+
+test_that("EPT partition: thin AOI parallel read equals serial AOI read exactly", {
+  skip_if_not(has_omp_support())
+  ept <- system.file("extdata", "ept-test-multi", "ept.json", package = "lasR")
+  q <- reader_rectangles(273360, 5274495, 273640, 5274505)  # thin strip
+  par <- exec(q + summarise(), on = ept, ncores = concurrent_files(4))
+  ser <- exec(q + summarise(), on = ept, ncores = sequential())
+  expect_equal(par$npoints,     ser$npoints)
+  expect_equal(par$z_histogram, ser$z_histogram)
+})
+
 test_that("EPT partition: rect AOI parallel write equals serial AOI summarise exactly", {
   skip_if_not(has_omp_support())
   ept <- system.file("extdata", "ept-test-multi", "ept.json", package = "lasR")

--- a/tests/testthat/test-ept.R
+++ b/tests/testthat/test-ept.R
@@ -314,15 +314,30 @@ test_that("callback honors get_buffered() flag (boundary semantics)", {
   # Flag forces "in buffer" regardless of geometry.
   expect_true(lasR:::.APITEST$cpp_callback_buffer_decide(
     TRUE,  5, 5, 0, 0, 10, 10, FALSE))
+  # No flag, inside core → "not in buffer".
   expect_false(lasR:::.APITEST$cpp_callback_buffer_decide(
     FALSE, 5, 5, 0, 0, 10, 10, FALSE))
+  # No flag, on inclusive xmax edge → geometric "not in buffer".
   expect_false(lasR:::.APITEST$cpp_callback_buffer_decide(
     FALSE, 10, 5, 0, 0, 10, 10, FALSE))
+  # No flag, past xmax → "in buffer" via geometry.
   expect_true(lasR:::.APITEST$cpp_callback_buffer_decide(
     FALSE, 11, 5, 0, 0, 10, 10, FALSE))
   # Motivating bug: flag set, point on xmax (non-global) → flag wins over geometry.
   expect_true(lasR:::.APITEST$cpp_callback_buffer_decide(
     TRUE,  10, 5, 0, 0, 10, 10, FALSE))
+  # No flag, past ymax → "in buffer" via Y-axis geometry.
+  expect_true(lasR:::.APITEST$cpp_callback_buffer_decide(
+    FALSE, 5, 11, 0, 0, 10, 10, FALSE))
+  # Flag set, point on ymax (non-global) → flag wins over Y-axis geometry.
+  expect_true(lasR:::.APITEST$cpp_callback_buffer_decide(
+    TRUE,  5, 10, 0, 0, 10, 10, FALSE))
+  # No flag, circular footprint, point outside inscribed circle but inside bbox.
+  expect_true(lasR:::.APITEST$cpp_callback_buffer_decide(
+    FALSE, 9, 9, 0, 0, 10, 10, TRUE))
+  # Flag set, circular footprint, point inside circle → flag wins.
+  expect_true(lasR:::.APITEST$cpp_callback_buffer_decide(
+    TRUE,  5, 5, 0, 0, 10, 10, TRUE))
 })
 
 test_that("writelas honors get_buffered() flag (boundary semantics)", {

--- a/tests/testthat/test-ept.R
+++ b/tests/testthat/test-ept.R
@@ -371,14 +371,19 @@ test_that("EPT partition: malformed sub-hierarchy with AOI → passthrough + war
   file.copy(list.files(file.path(src, "ept-hierarchy"), full.names = TRUE),
             file.path(dst, "ept-hierarchy"))
 
-  # Find a non-root sub-hierarchy page referenced from the root via -1.
-  root <- jsonlite::fromJSON(file.path(dst, "ept-hierarchy", "0-0-0-0.json"))
-  sub_keys <- names(root)[unlist(root) == -1]
-  skip_if(length(sub_keys) == 0,
-          "test fixture root has no -1 sub-page references")
-  broken_key <- sub_keys[1]
+  # Engineer a -1 sub-page reference in the root hierarchy. The
+  # fixture's root only contains leaves with positive counts, so we
+  # add our own pointer to a sub-page that exists on disk but is
+  # malformed. build_metadata returns on the first openable probe
+  # (one of the existing leaves) and never visits this; ensure_tiles
+  # walks the entire hierarchy and throws when it parses the malformed
+  # sub-page.
+  root_path <- file.path(dst, "ept-hierarchy", "0-0-0-0.json")
+  root <- jsonlite::fromJSON(root_path)
+  root[["2-0-0-0"]] <- -1L
+  jsonlite::write_json(root, root_path, auto_unbox = TRUE)
   writeLines("{ not valid json",
-             file.path(dst, "ept-hierarchy", paste0(broken_key, ".json")))
+             file.path(dst, "ept-hierarchy", "2-0-0-0.json"))
 
   endpoint <- file.path(dst, "ept.json")
   msg <- capture.output(

--- a/tests/testthat/test-ept.R
+++ b/tests/testthat/test-ept.R
@@ -399,3 +399,73 @@ test_that("EPT partition: malformed sub-hierarchy with AOI → passthrough + war
   expect_match(paste(msg, collapse = "\n"),
                "EPT hierarchy unavailable .* AOI partitioning skipped")
 })
+
+# ----- AOI partition: emission + owner bounds (spec rev 5 tests 2, 3, 4, 7, 8) -----
+
+test_that("EPT partition: multi-tile rect AOI yields >1 strict-clipped sub-queries", {
+  ept <- system.file("extdata", "ept-test-multi", "ept.json", package = "lasR")
+  insp <- lasR:::.APITEST$cpp_ept_partition_inspect(
+    ept, 16, list(c(273360, 5274360, 273640, 5274640)))
+  expect_gt(insp$nchunks, 1L)
+  expect_true(all(insp$strict_clip))
+  expect_true(all(as.character(insp$shape_type) == "rect"))
+  cb <- insp$conf_bounds
+  xmin_c <- max(273360, cb[1]); ymin_c <- max(5274360, cb[2])
+  xmax_c <- min(273640, cb[3]); ymax_c <- min(5274640, cb[4])
+  expect_true(all(insp$bbox[, 1] >= xmin_c - 1e-9))
+  expect_true(all(insp$bbox[, 2] >= ymin_c - 1e-9))
+  expect_true(all(insp$bbox[, 3] <= xmax_c + 1e-9))
+  expect_true(all(insp$bbox[, 4] <= ymax_c + 1e-9))
+  expect_true(all(abs(insp$owner_xmax - xmax_c) < 1e-9))
+  expect_true(all(abs(insp$owner_ymax - ymax_c) < 1e-9))
+})
+
+test_that("EPT partition: tiny AOI inside one cell emits one sub-query", {
+  ept <- system.file("extdata", "ept-test-multi", "ept.json", package = "lasR")
+  aoi <- c(273500, 5274500, 273505, 5274505)
+  insp <- lasR:::.APITEST$cpp_ept_partition_inspect(ept, 16, list(aoi))
+  expect_equal(insp$nchunks, 1L)
+  expect_true(insp$strict_clip[1])
+  expect_equal(insp$bbox[1, ], aoi, tolerance = 1e-9)
+  expect_equal(insp$owner_xmax[1], aoi[3], tolerance = 1e-9)
+  expect_equal(insp$owner_ymax[1], aoi[4], tolerance = 1e-9)
+})
+
+test_that("EPT partition: AOI extending past conf_bounds uses clamped owner_xmax", {
+  ept <- system.file("extdata", "ept-test-multi", "ept.json", package = "lasR")
+  base <- lasR:::.APITEST$cpp_ept_partition_inspect(ept, 1)
+  cb <- base$conf_bounds
+  aoi <- c(cb[1] + 10, cb[2] + 10, cb[3] + 1000, cb[4] + 1000)
+  insp <- lasR:::.APITEST$cpp_ept_partition_inspect(ept, 16, list(aoi))
+  expect_gt(insp$nchunks, 0L)
+  expect_true(all(insp$bbox[, 3] <= cb[3] + 1e-9))
+  expect_true(all(insp$bbox[, 4] <= cb[4] + 1e-9))
+  # CLAMPED owner_xmax (not the unclamped AOI max).
+  expect_true(all(abs(insp$owner_xmax - cb[3]) < 1e-9))
+  expect_true(all(abs(insp$owner_ymax - cb[4]) < 1e-9))
+})
+
+test_that("EPT partition: multiple disjoint AOIs each contribute sub-queries", {
+  ept <- system.file("extdata", "ept-test-multi", "ept.json", package = "lasR")
+  # Each AOI straddles the cell midline at x=273500 so it splits into >=2
+  # sub-queries; the two AOIs are disjoint in y. Total nchunks > length(aois)
+  # exercises the "each AOI is independently partitioned" intent.
+  aois <- list(
+    c(273360, 5274360, 273510, 5274490),
+    c(273490, 5274510, 273640, 5274640))
+  insp <- lasR:::.APITEST$cpp_ept_partition_inspect(ept, 16, aois)
+  expect_gt(insp$nchunks, length(aois))
+  expect_true(all(insp$owner_xmax %in% c(aois[[1]][3], aois[[2]][3])))
+})
+
+test_that("EPT partition: mixed rect + circle splits the rect, passes circle through", {
+  ept <- system.file("extdata", "ept-test-multi", "ept.json", package = "lasR")
+  insp <- lasR:::.APITEST$cpp_ept_partition_inspect(
+    ept, 16,
+    list(c(273360, 5274360, 273640, 5274640)),
+    list(c(273500, 5274500, 30)))
+  rects   <- as.character(insp$shape_type) == "rect"
+  circles <- as.character(insp$shape_type) == "circle"
+  expect_gt(sum(rects), 1L)
+  expect_equal(sum(circles), 1L)
+})

--- a/tests/testthat/test-ept.R
+++ b/tests/testthat/test-ept.R
@@ -514,6 +514,26 @@ test_that("EPT partition: rect AOI parallel read equals serial AOI read exactly"
   expect_equal(par$z_histogram, ser$z_histogram)
 })
 
+test_that("EPT auto-partition default target is 32 when LASR_EPT_PARTITIONS unset", {
+  skip_if_not(has_omp_support())
+  ept <- system.file("extdata", "ept-test-multi", "ept.json", package = "lasR")
+  aoi <- c(273360, 5274360, 273640, 5274640)
+  q <- reader_rectangles(aoi[1], aoi[2], aoi[3], aoi[4]) + summarise()
+  logf <- tempfile()
+  on.exit(unlink(logf), add = TRUE)
+  prev <- Sys.getenv("LASR_EPT_PARTITIONS", unset = NA)
+  on.exit({
+    if (is.na(prev)) Sys.unsetenv("LASR_EPT_PARTITIONS") else Sys.setenv(LASR_EPT_PARTITIONS = prev)
+  }, add = TRUE)
+  Sys.unsetenv("LASR_EPT_PARTITIONS")
+  exec(q, on = ept, ncores = concurrent_files(16), verbose = TRUE,
+       log_file = logf, progress = FALSE)
+  chunks <- as.integer(sub(".*Chunks: ([0-9]+).*", "\\1",
+                           grep("Chunks:", readLines(logf), value = TRUE)[1]))
+  insp32 <- lasR:::.APITEST$cpp_ept_partition_inspect(ept, 32, list(aoi))
+  expect_equal(chunks, insp32$nchunks)
+})
+
 test_that("EPT partition: depth iteration picks min d meeting target cell count", {
   # Unit-level test of the depth predicate. The local fixture's
   # max_tile_depth=1 caps both old (area ratio) and new (cell-count)

--- a/tests/testthat/test-ept.R
+++ b/tests/testthat/test-ept.R
@@ -306,6 +306,25 @@ test_that("summary honors get_buffered() flag (boundary semantics)", {
     TRUE,  5, 5, 0, 0, 10, 10, TRUE))
 })
 
+test_that("callback honors get_buffered() flag (boundary semantics)", {
+  # Same shape as the summary/writelas pins: the reader-set BUFFERED
+  # flag must drive callback's drop_buffer decision, otherwise the
+  # post-callback "Update the LAS" loop would re-classify points
+  # geometrically and miss strict-clipped boundary points.
+  # Flag forces "in buffer" regardless of geometry.
+  expect_true(lasR:::.APITEST$cpp_callback_buffer_decide(
+    TRUE,  5, 5, 0, 0, 10, 10, FALSE))
+  expect_false(lasR:::.APITEST$cpp_callback_buffer_decide(
+    FALSE, 5, 5, 0, 0, 10, 10, FALSE))
+  expect_false(lasR:::.APITEST$cpp_callback_buffer_decide(
+    FALSE, 10, 5, 0, 0, 10, 10, FALSE))
+  expect_true(lasR:::.APITEST$cpp_callback_buffer_decide(
+    FALSE, 11, 5, 0, 0, 10, 10, FALSE))
+  # Motivating bug: flag set, point on xmax (non-global) → flag wins over geometry.
+  expect_true(lasR:::.APITEST$cpp_callback_buffer_decide(
+    TRUE,  10, 5, 0, 0, 10, 10, FALSE))
+})
+
 test_that("writelas honors get_buffered() flag (boundary semantics)", {
   # Flag forces "drop" regardless of geometry.
   expect_false(lasR:::.APITEST$cpp_writelas_buffer_decide(

--- a/tests/testthat/test-ept.R
+++ b/tests/testthat/test-ept.R
@@ -268,3 +268,40 @@ test_that("strict-clip: zero buffer collapses buffer ring to nothing",
   # px == xmax (not global) → still inside buffered extent → BUFFERED.
   expect_equal(decide(10, 5, 0, 10, 0, 10, 0, 100, 100), BUFFERED)
 })
+
+# ----- Ownership contract: get_buffered() short-circuit (spec rev 5 test 10) -----
+#
+# The reader flags interior-boundary points BUFFERED via strict_clip_decide,
+# but summary.cpp:36 / writelas.cpp:97 historically recomputed inside_buffer()
+# geometrically (inclusive >), reaching the opposite verdict at the boundary.
+# These tests pin the new contract: the flag wins; geometry is the fallback.
+
+test_that("summary honors get_buffered() flag (boundary semantics)", {
+  # Flag forces "in buffer" regardless of geometry.
+  expect_true(lasR:::.APITEST$cpp_summary_buffer_decide(
+    TRUE,  5, 5, 0, 0, 10, 10, FALSE))
+  # No flag, inside core → "not in buffer".
+  expect_false(lasR:::.APITEST$cpp_summary_buffer_decide(
+    FALSE, 5, 5, 0, 0, 10, 10, FALSE))
+  # No flag, on the inclusive xmax edge → geometric "not in buffer".
+  expect_false(lasR:::.APITEST$cpp_summary_buffer_decide(
+    FALSE, 10, 5, 0, 0, 10, 10, FALSE))
+  # No flag, past xmax → "in buffer" via geometry.
+  expect_true(lasR:::.APITEST$cpp_summary_buffer_decide(
+    FALSE, 11, 5, 0, 0, 10, 10, FALSE))
+})
+
+test_that("writelas honors get_buffered() flag (boundary semantics)", {
+  # Flag forces "drop" regardless of geometry.
+  expect_false(lasR:::.APITEST$cpp_writelas_buffer_decide(
+    TRUE,  5, 5, 0, 0, 10, 10, FALSE))
+  # No flag, inside core → "write".
+  expect_true(lasR:::.APITEST$cpp_writelas_buffer_decide(
+    FALSE, 5, 5, 0, 0, 10, 10, FALSE))
+  # No flag, on xmax edge → geometric "write" (inclusive).
+  expect_true(lasR:::.APITEST$cpp_writelas_buffer_decide(
+    FALSE, 10, 5, 0, 0, 10, 10, FALSE))
+  # No flag, past xmax → "drop".
+  expect_false(lasR:::.APITEST$cpp_writelas_buffer_decide(
+    FALSE, 11, 5, 0, 0, 10, 10, FALSE))
+})

--- a/tests/testthat/test-ept.R
+++ b/tests/testthat/test-ept.R
@@ -499,6 +499,47 @@ test_that("EPT partition: rect AOI parallel read equals serial AOI read exactly"
   expect_equal(par$z_histogram, ser$z_histogram)
 })
 
+test_that("EPT partition: depth iteration picks min d meeting target cell count", {
+  # Unit-level test of the depth predicate. The local fixture's
+  # max_tile_depth=1 caps both old (area ratio) and new (cell-count)
+  # formulas to d=1, so an end-to-end test on it cannot discriminate.
+  # cpp_ept_pick_depth bypasses the EPT loader so we can exercise
+  # depths that real fixtures wouldn't reach.
+  pick <- lasR:::.APITEST$cpp_ept_pick_depth
+
+  # Square AOI fully covering the cube, target=4. cells_at(d=1) = 2*2 = 4.
+  expect_equal(pick(0, 0, 285, 8, 4, list(c(0, 0, 285, 285))), 1L)
+
+  # Square AOI fully covering the cube, target=16. cells_at(d=2) = 4*4 = 16.
+  expect_equal(pick(0, 0, 285, 8, 16, list(c(0, 0, 285, 285))), 2L)
+
+  # Long-thin AOI (280 × 5) with cap=8: the new formula correctly picks
+  # d=4 because the x dim spans 16 cells at d=4 while y stays at 1.
+  # Old formula picked d=5 (area ratio over-estimated). Validates the
+  # primary motivating case for the change.
+  expect_equal(pick(0, 0, 285, 8, 16, list(c(0, 0, 280, 5))), 4L)
+
+  # Same AOI under a shallow cap (max_tile_depth=2): clamped to d=2
+  # even though more cells would be needed to reach target=16.
+  expect_equal(pick(0, 0, 285, 2, 16, list(c(0, 0, 280, 5))), 2L)
+
+  # Two small disjoint AOIs that need d=2 to separate. At d=0 each AOI
+  # covers 1 cell so the sum is 2 — still < target=8. At d=1 each AOI
+  # still covers 1 cell (sum 2). At d=2 (cell=71.25m) each AOI covers
+  # ceil(30/71.25)=1 in each dim so sum=2 — still < target. Loop falls
+  # through to d=cap=3 where cells_at = ceil(30/35.6)=1 per side → 2
+  # total. With target=8 unreachable, d ends at cap. Verifies the cap
+  # behavior.
+  expect_equal(pick(0, 0, 285, 3, 8, list(
+    c(0,   0,   30,  30),
+    c(120, 120, 150, 150)
+  )), 3L)
+
+  # Degenerate inputs: target=0 → d=0. max_tile_depth=0 → d=0.
+  expect_equal(pick(0, 0, 285, 8, 0, list(c(0, 0, 100, 100))), 0L)
+  expect_equal(pick(0, 0, 285, 0, 16, list(c(0, 0, 100, 100))), 0L)
+})
+
 test_that("EPT partition: long-thin rect AOI produces multi-cell partition", {
   # The previous depth formula used aoi_area/cube_area, which undercounted
   # long-thin AOIs: a strip ~280 m × 5 m has tiny area but spans the cube

--- a/tests/testthat/test-ept.R
+++ b/tests/testthat/test-ept.R
@@ -363,13 +363,16 @@ test_that("EPT partition: malformed sub-hierarchy with AOI → passthrough + war
   dst <- file.path(tempdir(), "ept-broken-subhier")
   unlink(dst, recursive = TRUE)
   dir.create(dst, showWarnings = FALSE)
-  file.copy(file.path(src, "ept.json"), dst)
+  on.exit(unlink(dst, recursive = TRUE), add = TRUE)
+  stopifnot(file.copy(file.path(src, "ept.json"), dst))
   dir.create(file.path(dst, "ept-data"), showWarnings = FALSE)
   dir.create(file.path(dst, "ept-hierarchy"), showWarnings = FALSE)
-  file.copy(list.files(file.path(src, "ept-data"), full.names = TRUE),
-            file.path(dst, "ept-data"))
-  file.copy(list.files(file.path(src, "ept-hierarchy"), full.names = TRUE),
-            file.path(dst, "ept-hierarchy"))
+  stopifnot(all(file.copy(
+    list.files(file.path(src, "ept-data"), full.names = TRUE),
+    file.path(dst, "ept-data"))))
+  stopifnot(all(file.copy(
+    list.files(file.path(src, "ept-hierarchy"), full.names = TRUE),
+    file.path(dst, "ept-hierarchy"))))
 
   # Engineer a -1 sub-page reference in the root hierarchy. The
   # fixture's root only contains leaves with positive counts, so we
@@ -394,5 +397,5 @@ test_that("EPT partition: malformed sub-hierarchy with AOI → passthrough + war
   expect_equal(as.character(insp$shape_type), "rect")
   expect_equal(insp$bbox[1, ], c(273400, 5274400, 273600, 5274600))
   expect_match(paste(msg, collapse = "\n"),
-               "AOI partitioning skipped|hierarchy")
+               "EPT hierarchy unavailable .* AOI partitioning skipped")
 })

--- a/tests/testthat/test-ept.R
+++ b/tests/testthat/test-ept.R
@@ -289,6 +289,21 @@ test_that("summary honors get_buffered() flag (boundary semantics)", {
   # No flag, past xmax → "in buffer" via geometry.
   expect_true(lasR:::.APITEST$cpp_summary_buffer_decide(
     FALSE, 11, 5, 0, 0, 10, 10, FALSE))
+  # Motivating bug: flag set, point on xmax (non-global) → flag wins over geometry.
+  expect_true(lasR:::.APITEST$cpp_summary_buffer_decide(
+    TRUE,  10, 5, 0, 0, 10, 10, FALSE))
+  # No flag, past ymax → "in buffer" via Y-axis geometry.
+  expect_true(lasR:::.APITEST$cpp_summary_buffer_decide(
+    FALSE, 5, 11, 0, 0, 10, 10, FALSE))
+  # Flag set, point on ymax (non-global) → flag wins over Y-axis geometry.
+  expect_true(lasR:::.APITEST$cpp_summary_buffer_decide(
+    TRUE,  5, 10, 0, 0, 10, 10, FALSE))
+  # No flag, circular footprint, point outside inscribed circle but inside bbox → "in buffer".
+  expect_true(lasR:::.APITEST$cpp_summary_buffer_decide(
+    FALSE, 9, 9, 0, 0, 10, 10, TRUE))
+  # Flag set, circular footprint, point inside circle → flag wins over geometry.
+  expect_true(lasR:::.APITEST$cpp_summary_buffer_decide(
+    TRUE,  5, 5, 0, 0, 10, 10, TRUE))
 })
 
 test_that("writelas honors get_buffered() flag (boundary semantics)", {
@@ -304,4 +319,19 @@ test_that("writelas honors get_buffered() flag (boundary semantics)", {
   # No flag, past xmax → "drop".
   expect_false(lasR:::.APITEST$cpp_writelas_buffer_decide(
     FALSE, 11, 5, 0, 0, 10, 10, FALSE))
+  # Motivating bug: flag set, point on xmax (non-global) → flag forces drop over geometry.
+  expect_false(lasR:::.APITEST$cpp_writelas_buffer_decide(
+    TRUE,  10, 5, 0, 0, 10, 10, FALSE))
+  # No flag, past ymax → "drop" via Y-axis geometry.
+  expect_false(lasR:::.APITEST$cpp_writelas_buffer_decide(
+    FALSE, 5, 11, 0, 0, 10, 10, FALSE))
+  # Flag set, point on ymax (non-global) → flag forces drop over Y-axis geometry.
+  expect_false(lasR:::.APITEST$cpp_writelas_buffer_decide(
+    TRUE,  5, 10, 0, 0, 10, 10, FALSE))
+  # No flag, circular footprint, point outside inscribed circle but inside bbox → "drop".
+  expect_false(lasR:::.APITEST$cpp_writelas_buffer_decide(
+    FALSE, 9, 9, 0, 0, 10, 10, TRUE))
+  # Flag set, circular footprint, point inside circle → flag forces drop over geometry.
+  expect_false(lasR:::.APITEST$cpp_writelas_buffer_decide(
+    TRUE,  5, 5, 0, 0, 10, 10, TRUE))
 })

--- a/tests/testthat/test-remote.R
+++ b/tests/testthat/test-remote.R
@@ -154,3 +154,37 @@ test_that("remote EPT with depth works",
 
   expect_equal(ans_d1$npoints, ans_full$npoints)
 })
+
+test_that("remote EPT under concurrent_files matches sequential",
+{
+  skip_if_not_installed("httpuv")
+  skip_if_not(has_omp_support())
+
+  # Note: a counting custom app$call handler cannot be used here because
+  # httpuv routes app$call through the R event loop, which is blocked by
+  # the synchronous lasR exec call (deadlock). Existing remote tests use
+  # the C-native staticPaths path for this reason. The metadata-cache
+  # invariant (one ept.json fetch per pipeline, not per-chunk) is asserted
+  # at the C++ layer via cpp_ept_partition_inspect's tiles_built flag in
+  # tests/testthat/test-ept.R; this test verifies the parallel remote path
+  # produces identical results to sequential, exercising the same shared
+  # HierarchyIndex code paths over HTTP.
+
+  ept_local <- system.file("extdata", "ept-test-multi", "ept.json", package = "lasR")
+  data_dir <- dirname(ept_local)
+
+  port   <- httpuv::randomPort()
+  server <- httpuv::startServer("127.0.0.1", port,
+                                list(staticPaths = list("/" = data_dir)))
+  on.exit(httpuv::stopServer(server), add = TRUE)
+
+  url <- paste0("http://127.0.0.1:", port, "/ept.json")
+
+  ans_seq <- exec(reader() + summarise(), on = url, ncores = sequential())
+  ans_par <- exec(reader() + summarise(), on = url,
+                  ncores = concurrent_files(4))
+
+  expect_gt(ans_seq$npoints, 0)
+  expect_equal(ans_par$npoints, ans_seq$npoints)
+  expect_equal(ans_par$z_histogram, ans_seq$z_histogram)
+})


### PR DESCRIPTION
# Parallel EPT acquisition

Make `concurrent_files` actually parallelize EPT reads (today: 1 endpoint = 1 chunk → falls back to serial), and make it work *inside* user AOIs.

Three layers:

1. **Auto-partition.** `partition_ept` builds an octree-aligned grid clipped to `conf_bounds`, emits one strict-clipped sub-query per non-empty cell. Gated to `EPTFILE + parallelizable + !use_rcapi + ncpu_outer > 1`. Hierarchy walked once at catalog build, shared with every chunk's reader.
2. **AOI partition.** Rectangle AOIs partition octree-aligned inside the AOI bbox. Sub-queries inherit the AOI's outer bbox as `owner_xmax/ymax` so the strict-clip carve-out fires at the AOI edge → partitioned and un-partitioned AOI reads agree on boundary-coincident points. Non-rect queries pass through.
3. **Remote-fetch tuning.** Bakes `GDAL_DISABLE_READDIR_ON_OPEN=EMPTY_DIR`, `GDAL_HTTP_MULTIPLEX=YES`, `VSI_CACHE=TRUE` (64 MiB) via `CPLSetConfigOption` (user env wins). Skips LASlib's per-tile `VSIStatL` HEAD for `/ept-data/` paths. Parallel hierarchy walk (capped 8 concurrent) and intra-chunk tile prefetch (`std::async`, best-effort). Workers never touch R's C API — warnings flow back via result structs.

Also a load-bearing fix: `summary.cpp` and `writelas.cpp` now honor `Point::get_buffered()` before geometric `inside_buffer` — without this, strict-clip silently double-counts points on partition midlines. The fix exposed a pre-existing `inside_buffer(xmin, ymin, ymax, ymax, ...)` typo in `readlas.cpp`/`readpcd.cpp`, also corrected.

## Tests

- `test-ept.R`: end-to-end parallel correctness, partition shape, tiny/outside/circle/mixed AOIs, ownership-contract regression, hierarchy-failure passthrough, strict-clip boundary policy.
- `test-remote.R`: remote EPT correctness via `httpuv::startServer + staticPaths`.

## Benchmark
On a real remote EPT — USGS 3DEP `AZ_BrawleyRillito_TL_2018` (2.0 B points, native EPSG:3857) — a 10,000-acre AOI (58,636,837 points returned) is now **1.1×–1.6× faster than PDAL** at every concurrency level tested.


- **Endpoint:** `s3-us-west-2.amazonaws.com/usgs-lidar-public/AZ_BrawleyRillito_TL_2018/ept.json`
- **AOI:** 10,000 acres (40.5 km², 6,361 m × 6,361 m), inside `boundsConforming`
- **Pipeline:** `reader_rectangles(AOI) + summarise()` (lasR) and `readers.ept + filters.stats` (PDAL 2.10.1)
- **Host:** 16 vCPUs
- **Returned points:** 58,636,837 in every run — identical across lasR and PDAL single-process modes (correctness gate)

### lasR

| strategy             | wall (s) | speedup | parallel eff. | Mpts/s |
|----------------------|---------:|--------:|--------------:|-------:|
| sequential           |    65.6  |   1.00× |        100.0% |  0.89 |
| concurrent_files(2)  |    48.4  |   1.35× |         67.7% |  1.21 |
| concurrent_files(4)  |    33.0  |   1.99× |         49.7% |  1.78 |
| concurrent_files(8)  |    31.0  |   2.12× |         26.4% |  1.89 |
| concurrent_files(16) |    27.5  |   2.38× |         14.9% |  2.13 |

Outer-parallelism efficiency drops past `concurrent_files(4)` because the AWS S3 outbound pipe to this host saturates at ~4 concurrent fetches — PDAL hits the same wall (see below).

### PDAL (same AOI, same endpoint)

| mode                                | wall (s) | speedup vs `requests=1` |
|-------------------------------------|---------:|------------------------:|
| `requests=1`                        |   104.1  | 1.00× |
| `requests=2`                        |    53.0  | 1.96× |
| `requests=4`                        |    44.9  | 2.32× |
| `requests=8`                        |    45.4  | 2.29× |
| `requests=16`                       |    45.1  | 2.31× |
| 16 procs × `requests=1` (4×4 grid)  |    42.7  | 2.44× |

The 16-process PDAL variant returns 58,636,867 points — 30 extra. Each subprocess clips to its own sub-AOI without lasR's strict-clip ownership protocol, so a handful of grid-seam points get double-counted.

### Head-to-head

| concurrency | PDAL  | lasR  | lasR vs PDAL |
|------------:|------:|------:|-------------:|
|  1          | 104 s | **66 s** | **1.6× faster** |
|  2          |  53 s | **48 s** | **1.1× faster** |
|  4          |  45 s | **33 s** | **1.4× faster** |
|  8          |  45 s | **31 s** | **1.5× faster** |
| 16          |  43 s | **27 s** | **1.6× faster** |

