### PR TITLE
transform_with: add '=' operator to store raster values as-is

### DIFF
--- a/R/stages.R
+++ b/R/stages.R
@@ -1362,9 +1362,12 @@ triangulate = function(max_edge = 0, filter = "", ofile = "", use_attribute = "Z
 #'
 #' @param stage A stage that produces a triangulation, raster, or Rotation-Translation Matrix (RTM),
 #' sometimes also referred to as an "Affine Transformation Matrix". Can also be a 4x4 RTM matrix.
-#' @param operator A string. '-' and '+' are supported (only with a triangulation or a raster).
+#' @param operator A string. '-', '+' and '=' are supported (only with a triangulation or a
+#' raster). With '=' the raster (or TIN) value is stored as-is into `store_in_attribute`
+#' without any Z arithmetic; this is the typical way to attach a per-point label such as a
+#' tree-segmentation ID. '=' requires `store_in_attribute` to be set.
 #' @param store_in_attribute A string. Use an extra byte attribute to store the result (only with
-#' a triangulation or a raster).
+#' a triangulation or a raster). Required when `operator = "="`.
 #' @param bilinear bool. If the stage is a raster stage, the Z values are interpolated with a bilinear
 #' interpolation. FALSE to desactivate it.
 #'

--- a/R/stages.R
+++ b/R/stages.R
@@ -1346,9 +1346,11 @@ triangulate = function(max_edge = 0, filter = "", ofile = "", use_attribute = "Z
 #' Transform a Point Cloud Using Another Stage
 #'
 #' This stage uses another stage to modify the point cloud in the pipeline. When used with a Delaunay
-#' triangulation or a raster, it performs an operation to modify the Z coordinate of the point cloud.
-#' The interpolation method is linear in the triangle mesh and bilinear in the raster. This can typically
-#' be used to build a normalization stage.\cr
+#' triangulation or a raster and `operator = "-"` or `"+"`, the interpolated value is combined with the
+#' point Z coordinate (typically to build a normalization stage). When used with `operator = "="`, the
+#' interpolated value is written as-is into `store_in_attribute` without any Z arithmetic - useful for
+#' attaching per-point labels such as a tree-segmentation ID. The interpolation method is linear in the
+#' triangle mesh and bilinear in the raster.\cr
 #' When used with a 4x4 Rotation-Translation Matrix, it multiplies the coordinates of the points to apply
 #' the rigid transformation described by the matrix. This stage modifies the point cloud in the pipeline
 #' but does not produce any output.
@@ -1392,6 +1394,20 @@ triangulate = function(max_edge = 0, filter = "", ofile = "", use_attribute = "Z
 #'
 #' pipeline = transform_with(m) + write_las()
 #' exec(pipeline, on = f)
+#'
+#' # store a raster value as-is into an extra byte attribute (operator = "=").
+#' # Here we attach a tree-segmentation ID from region_growing() to each point.
+#' # Use add_extrabytes() with a wide enough type (tree IDs can exceed 255, so
+#' # 'UserData' - a 1-byte 0-255 LAS field - is not suitable here).
+#' g <- system.file("extdata", "MixedConifer.las", package="lasR")
+#' chm  <- rasterize(1, "max", filter = keep_first())
+#' lmx  <- local_maximum_raster(chm, 5)
+#' tree <- region_growing(chm, lmx, max_cr = 10)
+#' eb   <- add_extrabytes("int", "tree_id", "Tree segmentation ID")
+#' # bilinear = FALSE so the integer label is taken from the nearest pixel as-is.
+#' attr <- transform_with(tree, operator = "=", store_in_attribute = "tree_id", bilinear = FALSE)
+#' pipeline <- chm + lmx + tree + eb + attr + write_las()
+#' ans <- exec(pipeline, on = g)
 #' @seealso
 #' \link{triangulate}
 #' \link{write_las}

--- a/man/transform_with.Rd
+++ b/man/transform_with.Rd
@@ -10,10 +10,13 @@ transform_with(stage, operator = "-", store_in_attribute = "", bilinear = TRUE)
 \item{stage}{A stage that produces a triangulation, raster, or Rotation-Translation Matrix (RTM),
 sometimes also referred to as an "Affine Transformation Matrix". Can also be a 4x4 RTM matrix.}
 
-\item{operator}{A string. '-' and '+' are supported (only with a triangulation or a raster).}
+\item{operator}{A string. '-', '+' and '=' are supported (only with a triangulation or a
+raster). With '=' the raster (or TIN) value is stored as-is into \code{store_in_attribute}
+without any Z arithmetic; this is the typical way to attach a per-point label such as a
+tree-segmentation ID. '=' requires \code{store_in_attribute} to be set.}
 
 \item{store_in_attribute}{A string. Use an extra byte attribute to store the result (only with
-a triangulation or a raster).}
+a triangulation or a raster). Required when \code{operator = "="}.}
 
 \item{bilinear}{bool. If the stage is a raster stage, the Z values are interpolated with a bilinear
 interpolation. FALSE to desactivate it.}
@@ -23,9 +26,11 @@ This stage transforms the point cloud in the pipeline. It consequently returns n
 }
 \description{
 This stage uses another stage to modify the point cloud in the pipeline. When used with a Delaunay
-triangulation or a raster, it performs an operation to modify the Z coordinate of the point cloud.
-The interpolation method is linear in the triangle mesh and bilinear in the raster. This can typically
-be used to build a normalization stage.\cr
+triangulation or a raster and \code{operator = "-"} or \code{"+"}, the interpolated value is combined with the
+point Z coordinate (typically to build a normalization stage). When used with \code{operator = "="}, the
+interpolated value is written as-is into \code{store_in_attribute} without any Z arithmetic - useful for
+attaching per-point labels such as a tree-segmentation ID. The interpolation method is linear in the
+triangle mesh and bilinear in the raster.\cr
 When used with a 4x4 Rotation-Translation Matrix, it multiplies the coordinates of the points to apply
 the rigid transformation described by the matrix. This stage modifies the point cloud in the pipeline
 but does not produce any output.
@@ -58,6 +63,20 @@ m <- matrix(c(
 
 pipeline = transform_with(m) + write_las()
 exec(pipeline, on = f)
+
+# store a raster value as-is into an extra byte attribute (operator = "=").
+# Here we attach a tree-segmentation ID from region_growing() to each point.
+# Use add_extrabytes() with a wide enough type (tree IDs can exceed 255, so
+# 'UserData' - a 1-byte 0-255 LAS field - is not suitable here).
+g <- system.file("extdata", "MixedConifer.las", package="lasR")
+chm  <- rasterize(1, "max", filter = keep_first())
+lmx  <- local_maximum_raster(chm, 5)
+tree <- region_growing(chm, lmx, max_cr = 10)
+eb   <- add_extrabytes("int", "tree_id", "Tree segmentation ID")
+# bilinear = FALSE so the integer label is taken from the nearest pixel as-is.
+attr <- transform_with(tree, operator = "=", store_in_attribute = "tree_id", bilinear = FALSE)
+pipeline <- chm + lmx + tree + eb + attr + write_las()
+ans <- exec(pipeline, on = g)
 }
 \seealso{
 \link{triangulate}

--- a/python/bindings.cpp
+++ b/python/bindings.cpp
@@ -522,7 +522,7 @@ PYBIND11_MODULE(pylasr, m) {
                 throw std::invalid_argument("The stage must be a triangulation or a raster stage or a matrix stage.");
         }
         return api::transform_with(uid, operation, store_in_attribute, bilinear);
-    }, "Transform points using raster or matrix",
+    }, "Transform points using raster or matrix. operation: '-' or '+' to combine with point Z (e.g. HAG = Z - DTM); '=' to store the raster/TIN value as-is into store_in_attribute (requires store_in_attribute, typical for tree-ID style labels).",
     py::arg("connect_uid"), py::arg("operation") = "-", py::arg("store_in_attribute") = "", py::arg("bilinear") = true);
 
     // CRS operations

--- a/python/tests/test_functions.py
+++ b/python/tests/test_functions.py
@@ -362,6 +362,14 @@ class TestTransformations(unittest.TestCase):
         pipeline = pylasr.transform_with(raster, operation="-", bilinear=True)
         self.assertIsInstance(pipeline, pylasr.Pipeline)
 
+    def test_transform_with_set_operator(self):
+        """transform_with(operation='=') stores raster value as-is in a named attribute"""
+        raster = pylasr.rasterize(res=1.0, window=1.0, operators=["max"])
+        pipeline = pylasr.transform_with(
+            raster, operation="=", store_in_attribute="treeID"
+        )
+        self.assertIsInstance(pipeline, pylasr.Pipeline)
+
 
 class TestReaders(unittest.TestCase):
     """Test reader pipeline functions"""

--- a/src/LASRstages/transformwith.cpp
+++ b/src/LASRstages/transformwith.cpp
@@ -8,9 +8,23 @@ bool LASRtransformwith::set_parameters(const nlohmann::json& stage)
   attribute = stage.value("store_in_attribute", "");
   bilinear = stage.value("bilinear", true);
 
-  this->op = SUB;
-  if (op == "-") this->op = SUB;
-  if (op == "+") this->op = ADD;
+  if (op == "-")
+    this->op = SUB;
+  else if (op == "+")
+    this->op = ADD;
+  else if (op == "=")
+    this->op = SET;
+  else
+  {
+    last_error = "invalid operator '" + op + "'. Supported operators are '-', '+' and '='";
+    return false;
+  }
+
+  if (this->op == SET && attribute.empty())
+  {
+    last_error = "operator '=' requires 'store_in_attribute' to be set";
+    return false;
+  }
 
   return true;
 }
@@ -180,6 +194,12 @@ bool LASRtransformwith::process(PointCloud*& las)
 
       if (z == NA_F64)
       {
+        // SET assigns a label/value into a named attribute; on nodata
+        // we leave the existing attribute value untouched rather than
+        // dropping the point (which is the right behavior for HAG-style
+        // normalization but not for label-style assignment).
+        if (op == SET) continue;
+
         las->delete_point();
         deleted++;
         continue;
@@ -189,6 +209,7 @@ bool LASRtransformwith::process(PointCloud*& las)
       {
       case SUB: z = las->point.get_z() - z; break;
       case ADD: z = las->point.get_z() + z; break;
+      case SET: /* z is already the raster/TIN value, no Z math */ break;
       default: last_error = "internal error, invalid operator"; return false; break; // # nocov
       }
 

--- a/src/LASRstages/transformwith.h
+++ b/src/LASRstages/transformwith.h
@@ -22,7 +22,7 @@ private:
   int op;
   bool bilinear;
   std::string attribute;
-  enum operators {ADD, SUB};
+  enum operators {ADD, SUB, SET};
 };
 
 #endif

--- a/tests/testthat/test-transform_with.R
+++ b/tests/testthat/test-transform_with.R
@@ -106,6 +106,58 @@ test_that("tw can rotate with a matrix ",
   expect_equal(zrange, c(100.00, 129.97))
 })
 
+test_that("tw with operator '=' stores raster value as-is into a per-point attribute",
+{
+  f = system.file("extdata", "MixedConifer.las", package="lasR")
+
+  reader = reader_las(filter = "-keep_first")
+  chm = rasterize(1, "max")
+  lmx = local_maximum(5)
+  tree = region_growing(chm, lmx, max_cr = 10)
+  exby = add_extrabytes("int", "MYTID", "tree segmentation ID")
+  # Use nearest-neighbor sampling so the integer label is preserved exactly.
+  set  = transform_with(tree, operator = "=", store_in_attribute = "MYTID", bilinear = FALSE)
+
+  olas = templas()
+  pipeline = reader + chm + lmx + tree + exby + set + write_las(olas)
+  ans = exec(pipeline, on = f)
+
+  read = reader_las() + callback(function(data) { return(data$MYTID) }, expose = "E")
+  ids  = exec(read, on = ans$write_las)
+
+  expect_true(any(ids > 0))                  # at least some points were labelled
+  expect_true(any(ids == 0))                 # unsegmented points kept their default 0 (not deleted)
+
+  # With nearest-neighbor sampling the per-point IDs must be a subset of the raster IDs.
+  raster_ids = sort(unique(na.omit(as.numeric(ans$region_growing[]))))
+  point_ids  = sort(unique(ids[ids > 0]))
+  expect_true(all(point_ids %in% raster_ids))
+})
+
+test_that("tw operator '=' requires store_in_attribute",
+{
+  f = system.file("extdata", "Topography.las", package="lasR")
+
+  mesh = triangulate(50, filter = keep_ground())
+  dtm  = rasterize(1, mesh, ofile = "")
+  bad  = transform_with(dtm, operator = "=")
+  pipeline = reader_las() + mesh + dtm + bad
+
+  expect_error(exec(pipeline, on = f), "store_in_attribute")
+})
+
+test_that("tw rejects an unsupported operator",
+{
+  f = system.file("extdata", "Topography.las", package="lasR")
+
+  mesh = triangulate(50, filter = keep_ground())
+  dtm  = rasterize(1, mesh, ofile = "")
+  bad  = transform_with(dtm, operator = "*")
+  pipeline = reader_las() + mesh + dtm + bad
+
+  expect_error(exec(pipeline, on = f), "invalid operator")
+})
+
 test_that("tw fails with non orthogonal matrix",
 {
   f <- system.file("extdata", "Example.las", package="lasR")


### PR DESCRIPTION
## Summary

Implements [#311](https://github.com/r-lidar/lasR/discussions/311).

- Adds `SET` to `LASRtransformwith::operators` and accepts `operator = "="` in `set_parameters()`. For `=`, the per-point switch writes the raster (or TIN) value directly into `store_in_attribute` with no Z arithmetic — the canonical use is attaching a tree-ID from `region_growing()` to each point in one pipeline pass.
- Hardens the operator parser: unknown operators now error instead of silently falling back to `-`. `=` errors out if `store_in_attribute` is empty 
- On raster-nodata pixels, `=` leaves the existing attribute value untouched instead of deleting the point. Deleting was correct for HAG-style normalization but wrong for label-style assignment (e.g. unsegmented points outside any tree would otherwise drop out of the cloud).
- R doc (`?transform_with`) and the Python binding docstring updated to mention `=` and the `store_in_attribute` requirement.
