### PR TITLE
fix: include macros.h in LASio.cpp for MAX macro

### DIFF
--- a/src/LASRreaders/LASio.cpp
+++ b/src/LASRreaders/LASio.cpp
@@ -1,5 +1,6 @@
 #include "LASio.h"
 #include "Progress.h"
+#include "macros.h"
 
 #include "lasreader.hpp"
 #include "laswriter.hpp"


### PR DESCRIPTION
## Summary

- `src/LASRreaders/LASio.cpp` uses `MAX(a,b)` at lines 196 and 621 but never explicitly included `LASRcore/macros.h`. It compiled only because GDAL's `cpl_port.h` defined `MAX`/`MIN` as convenience macros, pulled in transitively via `Header.h → CRS.h → gdal_priv.h`.
- **GDAL 3.13.0 removed those macros** from `cpl_port.h` (present in [v3.12.4 lines 362/364](https://github.com/OSGeo/gdal/blob/v3.12.4/port/cpl_port.h#L362), gone in [v3.13.0](https://github.com/OSGeo/gdal/blob/v3.13.0/port/cpl_port.h)). When the macOS runner picks up gdal 3.13, compilation fails with `error: use of undeclared identifier 'MAX'`.
- Fix is a one-line `#include "macros.h"`.

## How this surfaced

Devel run [25853585263](https://github.com/r-lidar/lasR/actions/runs/25853585263) — `test-coverage` job installed `gdal/3.13.0` and failed; the parallel `R-CMD-check` job on the same SHA happened to install `gdal/3.12.4` and passed. Same `macos-latest` / Xcode 16.4 / MacOSX15.5.sdk — only difference was the Homebrew bottle that won the race.

## Audit of related code

Four other sites use `MAX`/`MIN` without an explicit `#include "macros.h"` — `LASRcore/FileCollection.cpp:464`, `LASRcore/parser.cpp:572`, `LASRstages/rasterize.h:14`, `LASRstages/aggregate.h:15`. They still compile because each transitively pulls `macros.h` in through `Grid.h`. Not fixing them here to keep this PR minimal, but they're fragile.

## Test plan

- [ ] CI green on `test-coverage` (macOS, the workflow that originally failed)
- [ ] CI green on `R-CMD-check` (macOS / ubuntu / windows)
- [ ] `pylasr.yaml` still green