### PR TITLE
Fix out-of-bounds heap read in classify_with_csf (#321)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,7 @@
 
 - Fix #323 streaming bounding box filter
 - Fix #317 ptd by passes if 0 points instead of error.
+- Fix: `classify_with_csf()` no longer reads one element past the end of the ground-index vector once all ground points have been matched, which caused an out-of-bounds heap read on nearly every call (#321)
 
 # lasR 0.21.0
 

--- a/src/LASRstages/csf.cpp
+++ b/src/LASRstages/csf.cpp
@@ -47,7 +47,7 @@ bool LASRcsf::process(PointCloud*& las)
   {
     if (pointfilter.filter(&las->point)) continue;
 
-    if (i == ground[k])
+    if (k < (int)ground.size() && i == ground[k])
     {
       k++;
       if (set_and_get_classification(&las->point) != 9) set_and_get_classification(&las->point, classification);
@@ -194,7 +194,7 @@ else
   int k = 0;
   while(las->read_point())
   {
-    if (i == ground[k])
+    if (k < (int)ground.size() && i == ground[k])
     {
       k++;
       if (las->pointoint.classification != 9) // Preserve water

--- a/tests/testthat/test-csf.R
+++ b/tests/testthat/test-csf.R
@@ -21,3 +21,20 @@ test_that("CSF works with a filter",
   names(class) = c(0,1,2,9)
   expect_equal(ans$npoints_per_class, class, tolerance = 1)
 })
+
+test_that("CSF does not read past the ground index vector (#321)",
+{
+  # Regression test for #321: once all ground indices have been matched, the
+  # classification loop used to evaluate ground[k] with k == ground.size() for
+  # every remaining (non-ground) point, an out-of-bounds heap read. Point clouds
+  # almost always end on non-ground points, so the read happened on nearly every
+  # call. The run must complete and conserve the total point count; under
+  # AddressSanitizer/valgrind this also catches the out-of-bounds access itself.
+  f <- system.file("extdata", "Topography.las", package="lasR")
+
+  pipeline = classify_with_csf(TRUE, 1, 1, time_step = 1, filter = "") + summarise()
+  ans = exec(pipeline, on = f)
+
+  expect_true(sum(ans$npoints_per_class) == ans$npoints)
+  expect_true(ans$npoints_per_class[["2"]] > 0)
+})


### PR DESCRIPTION
## Summary

Fixes #321 — an out-of-bounds heap read in `LASRcsf::process` (`src/LASRstages/csf.cpp`).

The classification loop matched sorted ground indices against the running point index:

```cpp
if (i == ground[k]) { k++; ... }
```

It read `ground[k]` without checking `k < ground.size()`. Once all ground indices have been matched, `k == ground.size()` and every remaining (non-ground) point still evaluated `ground[k]` — reading one `int` past the end of the vector. Because point clouds almost always end on non-ground points, this happened on essentially every call.

## Fix

Add a short-circuiting bounds check before dereferencing:

```cpp
if (k < (int)ground.size() && i == ground[k]) { k++; ... }
```

While `k` is in range the behaviour is identical; once all ground points are matched the index is simply no longer evaluated. The same pattern in the commented-out experimental block (~line 197) is fixed for consistency.

## Verification

- Reproduced the exact defect with a minimal AddressSanitizer harness mirroring the loop: `READ of size 4 ... 0 bytes after` the `ground` allocation — matching the reporter's "one `int` (4 bytes) past the vector" observation. The fixed variant runs clean and returns the same ground count.
- Built the package and ran `tests/testthat/test-csf.R`: all pass, including a new regression test (`CSF does not read past the ground index vector (#321)`) that exercises the trailing-non-ground-point path and checks the total point count is conserved. Under CRAN's ASan/valgrind checks this test also trips the underlying out-of-bounds access on the unfixed code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)