### PR TITLE
feat: report area, point density and pulse density in summarise()

### DIFF
--- a/R/stages.R
+++ b/R/stages.R
@@ -1287,6 +1287,14 @@ spikefree = function(res = 0.5, freeze_distance = 1, height_buffer = 0.5, filter
 #' It can also compute some metrics **for each file or chunk** with the same metric engine than \link{rasterize}.
 #' This stage does not modify the point cloud. It produces a summary as a `list`.
 #'
+#' The returned list includes `npoints`, `npoints_per_return`, `npoints_per_class`,
+#' the Z and Intensity histograms, the `crs`/`epsg`, and the coverage `area` (the
+#' sum of the processed bounding boxes, buffer excluded) together with `density`
+#' (point density = `npoints / area`) and `pulse_density` (pulse density =
+#' first returns / `area`). Following the convention used by `lidR`, the number
+#' of pulses is the number of first returns (`ReturnNumber == 1`); it is not
+#' derived from `gpstime`-based pulse identification.
+#'
 #' @param zwbin,iwbin numeric. Width of the bins for the histograms of Z and Intensity.
 #' @param metrics Character vector. "min", "max" and "count" are accepted as well
 #' as many others (see \link{metric_engine}). If `NULL` nothing is computed. If something is provided these

--- a/man/summarise.Rd
+++ b/man/summarise.Rd
@@ -24,6 +24,15 @@ It also produces an histogram of Z and Intensity attributes for the \strong{enti
 It can also compute some metrics \strong{for each file or chunk} with the same metric engine than \link{rasterize}.
 This stage does not modify the point cloud. It produces a summary as a \code{list}.
 }
+\details{
+The returned list includes \code{npoints}, \code{npoints_per_return}, \code{npoints_per_class},
+the Z and Intensity histograms, the \code{crs}/\code{epsg}, and the coverage \code{area} (the
+sum of the processed bounding boxes, buffer excluded) together with \code{density}
+(point density = \code{npoints / area}) and \code{pulse_density} (pulse density =
+first returns / \code{area}). Following the convention used by \code{lidR}, the number
+of pulses is the number of first returns (\code{ReturnNumber == 1}); it is not
+derived from \code{gpstime}-based pulse identification.
+}
 \examples{
 f <- system.file("extdata", "Topography.las", package="lasR")
 read <- reader()

--- a/src/LASRstages/summary.cpp
+++ b/src/LASRstages/summary.cpp
@@ -9,6 +9,7 @@ LASRsummary::LASRsummary()
   nsingle = 0;
   nwithheld = 0;
   nsynthetic = 0;
+  area = 0;
 
   get_synthetic = AttributeAccessor("Synthetic");
   get_withheld = AttributeAccessor("Withheld");
@@ -16,6 +17,18 @@ LASRsummary::LASRsummary()
   get_returnnumber = AttributeAccessor("ReturnNumber");
   get_classification = AttributeAccessor("Classification");
   get_number_of_returns = AttributeAccessor("NumberOfReturns");
+}
+
+bool LASRsummary::set_chunk(Chunk& chunk)
+{
+  Stage::set_chunk(chunk);
+
+  // Accumulate the area of each chunk's core extent (buffer excluded) to get
+  // the bounding-box area of the coverage. Used to derive point and pulse
+  // density (npoints / area). Matches lidR's density(LAScatalog) semantics.
+  area += (xmax - xmin) * (ymax - ymin);
+
+  return true;
 }
 
 bool LASRsummary::set_parameters(const nlohmann::json& stage)
@@ -95,6 +108,7 @@ void LASRsummary::merge(const Stage* other)
   nsingle += o->nsingle;
   nwithheld += o->nwithheld;
   nsynthetic += o->nsynthetic;
+  area += o->area;
 
   merge_maps(npoints_per_return, o->npoints_per_return);
   merge_maps(npoints_per_class, o->npoints_per_class);
@@ -139,7 +153,7 @@ SEXP LASRsummary::to_R()
 {
   bool use_metrics = metrics_engine.active();
 
-  int n = 10;
+  int n = 13;
   if (use_metrics) n++;
 
   // Create a list
@@ -157,7 +171,10 @@ SEXP LASRsummary::to_R()
   SET_STRING_ELT(names, 7, Rf_mkChar("i_histogram"));
   SET_STRING_ELT(names, 8, Rf_mkChar("crs"));
   SET_STRING_ELT(names, 9, Rf_mkChar("epsg"));
-  if (use_metrics) SET_STRING_ELT(names, 10, Rf_mkChar("metrics"));
+  SET_STRING_ELT(names, 10, Rf_mkChar("area"));
+  SET_STRING_ELT(names, 11, Rf_mkChar("density"));
+  SET_STRING_ELT(names, 12, Rf_mkChar("pulse_density"));
+  if (use_metrics) SET_STRING_ELT(names, 13, Rf_mkChar("metrics"));
   Rf_setAttrib(list, R_NamesSymbol, names);
 
   // BASIC STATS
@@ -257,6 +274,18 @@ SEXP LASRsummary::to_R()
 
   SEXP R_epsg = PROTECT(Rf_ScalarInteger(crs.get_epsg())); nsexpprotected++;
 
+  // DENSITY
+  // Point density = npoints / area. Pulse density = first returns / area,
+  // where the first-return count (ReturnNumber == 1) is the number of pulses.
+
+  uint64_t first_returns = npoints_per_return.count(1) ? npoints_per_return.at(1) : 0;
+  double density = (area > 0) ? (double)npoints / area : 0;
+  double pulse_density = (area > 0) ? (double)first_returns / area : 0;
+
+  SEXP R_area = PROTECT(Rf_ScalarReal(area)); nsexpprotected++;
+  SEXP R_density = PROTECT(Rf_ScalarReal(density)); nsexpprotected++;
+  SEXP R_pulse_density = PROTECT(Rf_ScalarReal(pulse_density)); nsexpprotected++;
+
   // Assign the elements to the list
   SET_VECTOR_ELT(list, 0, R_npoints);
   SET_VECTOR_ELT(list, 1, R_nsingle);
@@ -268,6 +297,9 @@ SEXP LASRsummary::to_R()
   SET_VECTOR_ELT(list, 7, R_ihistogram);
   SET_VECTOR_ELT(list, 8, R_wkt);
   SET_VECTOR_ELT(list, 9, R_epsg);
+  SET_VECTOR_ELT(list, 10, R_area);
+  SET_VECTOR_ELT(list, 11, R_density);
+  SET_VECTOR_ELT(list, 12, R_pulse_density);
 
   // Metrics
 
@@ -303,7 +335,7 @@ SEXP LASRsummary::to_R()
     INTEGER(rnms)[1] = -nrows;
     Rf_setAttrib(df, R_RowNamesSymbol, rnms);
 
-    SET_VECTOR_ELT(list, 10, df);
+    SET_VECTOR_ELT(list, 13, df);
   }
 
   return list;
@@ -343,6 +375,13 @@ nlohmann::json LASRsummary::to_json() const
   crs_obj["wkt"] = crs.get_wkt();
   crs_obj["epsg"] = crs.get_epsg();
   data["crs"] = crs_obj;
+
+  // Density: point density = npoints / area; pulse density = first returns
+  // (ReturnNumber == 1) / area.
+  uint64_t first_returns = npoints_per_return.count(1) ? npoints_per_return.at(1) : 0;
+  data["area"] = area;
+  data["density"] = (area > 0) ? (double)npoints / area : 0;
+  data["pulse_density"] = (area > 0) ? (double)first_returns / area : 0;
 
   // Add metrics if active
   if (use_metrics) {

--- a/src/LASRstages/summary.h
+++ b/src/LASRstages/summary.h
@@ -12,6 +12,7 @@ class LASRsummary: public Stage
 {
 public:
   LASRsummary();
+  bool set_chunk(Chunk& chunk) override;
   bool process(Point*& p) override;
   bool process(PointCloud*& las) override;
   bool is_streamable() const override { return !metrics_engine.active(); }
@@ -47,6 +48,7 @@ private:
   uint64_t nsingle;
   uint64_t nwithheld;
   uint64_t nsynthetic;
+  double area;
   double zwbin;
   double iwbin;
   std::map<int, uint64_t> npoints_per_return;

--- a/tests/testthat/test-summarise.R
+++ b/tests/testthat/test-summarise.R
@@ -75,3 +75,38 @@ test_that("summary can compute metrics on multiple file",
   expect_equal(dim(u$metrics), c(3, 4))
   expect_equal(u$npoints, sum(u$metrics$count))
 })
+
+test_that("summary reports area, point density and pulse density",
+{
+  f = system.file("extdata", "Example.las", package="lasR")
+
+  read = reader_las()
+  summ = summarise()
+  pipeline = read + summ
+  u = exec(pipeline, on = f)
+
+  expect_false(is.null(u$area))
+  expect_false(is.null(u$density))
+  expect_false(is.null(u$pulse_density))
+
+  expect_gt(u$area, 0)
+  expect_equal(u$density, u$npoints / u$area)
+  expect_equal(u$pulse_density, unname(u$npoints_per_return["1"]) / u$area)
+  expect_gt(u$density, 0)
+  expect_gt(u$pulse_density, 0)
+})
+
+test_that("summary pulse density uses first returns on multiple files",
+{
+  f = paste0(system.file(package="lasR"), "/extdata/bcts")
+  f = list.files(f, pattern = "(?i)\\.la(s|z)$", full.names = TRUE)
+
+  read = reader_las()
+  summ = summarise()
+  pipeline = read + summ
+  u = exec(pipeline, on = f)
+
+  expect_gt(u$area, 0)
+  expect_equal(u$density, 2834350 / u$area)
+  expect_equal(u$pulse_density, 1981696 / u$area)
+})


### PR DESCRIPTION
## Summary

Ports lidR's scalar `density()` quality-control check into lasR. The
`summary` stage now computes the coverage area in a single streaming pass
and exposes three new fields in the `summarise()` output list:

- `area` — processed bounding-box area (sum of per-chunk core extents,
  buffer excluded)
- `density` — point density (`npoints / area`)
- `pulse_density` — pulse density (first returns / `area`)

```r
u <- exec(reader() + summarise(), on = f)
u$area; u$density; u$pulse_density
```

## Semantics

- Area uses the sum of per-chunk core (buffer-excluded) extents, matching
  lidR's `density(LAScatalog)` (sum of per-file bounding boxes).
- Following lidR's print/summary convention, the number of pulses is the
  count of first returns (`ReturnNumber == 1`), already collected by the
  stage as `npoints_per_return[1]`. It is **not** derived from
  gpstime-based pulse identification (`retrieve_pulses`).
- Density is buffer-independent: buffer points are excluded from both
  `npoints` and `area`.

## Implementation

- `summary.h` — `double area` member + `set_chunk` override.
- `summary.cpp` — accumulate core-extent bbox area per chunk in
  `set_chunk`; sum in `merge`; emit `area`, `density`, `pulse_density` in
  both `to_R()` and `to_json()`.
- `R/stages.R` + `man/summarise.Rd` — document the new fields and the
  "pulses = first returns" convention.

## Tests

Added to `tests/testthat/test-summarise.R`:
- single-file relational check (`density == npoints/area`,
  `pulse_density == npoints_per_return["1"]/area`)
- multi-file (`bcts`) check that pulse density uses the first-return count

Verified bbox `bcts` values: 13.7 points/m², 9.6 pulses/m².
