### PR TITLE
Fix heap-corrupting data race in thread_safe_print

### DIFF
--- a/src/LASRcore/print.cpp
+++ b/src/LASRcore/print.cpp
@@ -8,6 +8,7 @@
 #include <R_ext/Error.h>
 
 #include <string>
+#include <thread>
 #include <vector>
 
 #define MESSAGELVL 0
@@ -17,7 +18,14 @@
 // Global vector to store messages
 std::vector<std::pair<int, std::string>> message_queue;
 
-// Function to print and clear the queue (only called by thread 0)
+// Thread id captured at library load = the main R thread. Used to decide who
+// may touch R's C API (Rprintf/REprintf). omp_get_thread_num() is unsafe for
+// this check: it returns 0 for std::async / background threads that are not in
+// any OpenMP team, which would let them call into R off the main thread.
+static const std::thread::id g_main_thread_id = std::this_thread::get_id();
+
+// Function to print and clear the queue (only called by the main thread, under
+// the queue_mutex critical)
 void print_queue()
 {
   for (const auto &message : message_queue)
@@ -45,17 +53,18 @@ void print_queue()
 // Function to add a message to the queue
 void thread_safe_print(int level, const char *buffer)
 {
+  // A SINGLE lock guards both the push and the drain, so the global queue is
+  // never mutated concurrently. Only the main R thread drains it (i.e. touches
+  // R's C API). Previously push used critical(queue_mutex) and drain used
+  // critical(Rprint) -- two different locks on the same std::vector -- so a
+  // worker's push_back could run concurrently with the main thread's
+  // clear()/iterate, corrupting the heap under load (segfault / double free
+  // observed on large concurrent EPT reads).
   #pragma omp critical (queue_mutex)
   {
     message_queue.push_back({level, buffer});
-  }
-
-  if (omp_get_thread_num() == 0)
-  {
-    #pragma omp critical (Rprint)
-    {
+    if (std::this_thread::get_id() == g_main_thread_id)
       print_queue();
-    }
   }
 }
 


### PR DESCRIPTION
`thread_safe_print` guards the `message_queue` push with `critical(queue_mutex)`, but the drain (`print_queue()` — iterate + `clear()`) with a *different* lock, `critical(Rprint)`. Two named locks over one global `std::vector` provide no mutual exclusion against each other, so a worker thread's `push_back` can run concurrently with the main thread's `clear()`/iterate and corrupt the heap.

Surfaced nondeterministically (segfault, double free, `malloc(): unaligned tcache chunk`) on large `concurrent_files` EPT reads — reproduced reliably at `concurrent_files(16)` over a ~1.1B-point AOI; lower concurrency or smaller chunks mask it.

Fix:
- one lock for both the push and the drain, so the queue is never mutated concurrently;
- gate the drain on the real main-thread id (`std::this_thread::get_id()` captured at load) instead of `omp_get_thread_num()`, which returns 0 for `std::async` prefetch threads that are not in any OpenMP team and would otherwise let them touch R's C API off the main thread.

Verified with a clean-build A/B on identical source at 1.1B points: pre-fix crashed 2/2 at `cf16`, post-fix ran 3/3 clean.
